### PR TITLE
Additional fixes for 'GLib-CRITICAL: Source ID was not found..' messages

### DIFF
--- a/src/ck-event-logger.c
+++ b/src/ck-event-logger.c
@@ -435,6 +435,7 @@ ck_event_logger_finalize (GObject *object)
 
         if (event_logger->priv->event_queue != NULL) {
                 g_async_queue_unref (event_logger->priv->event_queue);
+                event_logger->priv->event_queue = NULL;
         }
 
         if (event_logger->priv->file != NULL) {

--- a/src/ck-vt-monitor.c
+++ b/src/ck-vt-monitor.c
@@ -540,6 +540,7 @@ ck_vt_monitor_finalize (GObject *object)
 
         if (vt_monitor->priv->event_queue != NULL) {
                 g_async_queue_unref (vt_monitor->priv->event_queue);
+                vt_monitor->priv->event_queue = NULL;
         }
 
         if (vt_monitor->priv->vt_thread_hash != NULL) {


### PR DESCRIPTION
I'm on Gentoo and still run 0.4.6 which continuously spews those notorious "GLib_CRITICAL" warnings. After applying commit 0b79d92001450e7f359212d4273100628f6a1693 I was still getting those messages - less, but repeatably e.g. on ssh logout. After digging through various distributions' bug reports _I think_ fields used for g_async_queue_unref() also need to be nulled out during finalization.
Disclaimer: I have nil experience with GTK/Glib, so this might be horribly wrong; so far it seems to work without explosions.
