### PR TITLE
Add --with-rundir configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,21 @@ fi
 Z_LIBS="${Z_LIBS} -lz"
 AC_SUBST(Z_LIBS)
 
+
+dnl ---------------------------------------------------------------------------
+dnl - Path to rundir e.g. /var/run
+dnl ---------------------------------------------------------------------------
+
+AC_ARG_WITH(rundir,
+	[AS_HELP_STRING([--with-rundir=<dir>],[run directory location, e.g. /var/run])])
+if ! test -z "$with_rundir" ; then
+        RUNDIR="$with_rundir"
+else
+        RUNDIR="$localstatedir/run"
+fi
+AC_SUBST(RUNDIR)
+
+
 dnl ---------------------------------------------------------------------------
 dnl - PID file
 dnl ---------------------------------------------------------------------------
@@ -173,7 +188,7 @@ AC_ARG_WITH(pid-file,
 if ! test -z "$with_pid_file"; then
    CONSOLE_KIT_PID_FILE=$with_pid_file
 else
-   CONSOLE_KIT_PID_FILE=${localstatedir}/run/ConsoleKit/pid
+   CONSOLE_KIT_PID_FILE=${RUNDIR}/ConsoleKit/pid
 fi
 
 AC_SUBST(CONSOLE_KIT_PID_FILE)
@@ -472,6 +487,7 @@ AC_SUBST(PACKAGE)
 AC_CONFIG_FILES([
 Makefile
 src/Makefile
+tools/70-udev-acl.rules
 tools/Makefile
 tools/linux/Makefile
 tools/freebsd/Makefile
@@ -479,6 +495,7 @@ tools/openbsd/Makefile
 tools/solaris/Makefile
 data/Makefile
 doc/Makefile
+doc/console-kit-daemon.1m
 doc/dbus/ConsoleKit.xml
 doc/dbus/Makefile
 libck-connector/Makefile
@@ -500,6 +517,7 @@ echo "
         sbindir:                  ${sbindir}
         sysconfdir:               ${sysconfdir}
         localstatedir:            ${localstatedir}
+        rundir:                   ${RUNDIR}
         datadir:                  ${datadir}
 	source code location:	  ${srcdir}
 	compiler:		  ${CC}

--- a/doc/console-kit-daemon.1m.in
+++ b/doc/console-kit-daemon.1m.in
@@ -49,7 +49,7 @@ used as a utmp/wtmp replacement since it stores a superset of the information
 as in the utmp/wtmp database\&.
 .PP
 The ConsoleKit database is stored in the file
-\fB/var/run/ConsoleKit/database\fR\&.  It stores information about
+\fB@RUNDIR@/ConsoleKit/database\fR\&.  It stores information about
 active Seats, Sessions, and the current SessionLeader\&.
 .SH "OPTIONS"
 .PP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ AM_CFLAGS =							\
 	-DDATADIR=\""$(datadir)"\"				\
 	-DSYSCONFDIR=\""$(sysconfdir)"\" 			\
 	-DLOCALSTATEDIR=\""$(localstatedir)"\" 			\
+	-DRUNDIR=\""$(RUNDIR)"\" 				\
 	-DCONSOLE_KIT_PID_FILE=\""$(CONSOLE_KIT_PID_FILE)"\"	\
 	-DLOCALEDIR=\"$(localedir)\"		\
 	$(WARN_CFLAGS)						\
@@ -211,8 +212,8 @@ test_tty_idle_monitor_LDADD =		\
 
 test_inhibit_CFLAGS = \
 	$(AM_CFLAGS)	\
-	-ULOCALSTATEDIR	\
-	-DLOCALSTATEDIR=\"/tmp\" 			\
+	-URUNDIR	\
+	-DRUNDIR=\"/tmp\" 			\
 	$(NULL)
 
 test_inhibit_SOURCES = 	\
@@ -251,5 +252,5 @@ install-data-local:
 	-mkdir -p $(DESTDIR)$(prefix)/lib/ConsoleKit/run-session.d
 	-mkdir -p $(DESTDIR)$(sysconfdir)/ConsoleKit/run-seat.d
 	-mkdir -p $(DESTDIR)$(prefix)/lib/ConsoleKit/run-seat.d
-	-mkdir -p $(DESTDIR)$(localstatedir)/run/ConsoleKit
+	-mkdir -p $(DESTDIR)$(RUNDIR)/ConsoleKit
 	-mkdir -p $(DESTDIR)$(localstatedir)/log/ConsoleKit

--- a/src/ck-inhibit.c
+++ b/src/ck-inhibit.c
@@ -216,19 +216,19 @@ create_inhibit_base_directory (void)
         gint res;
 
         errno = 0;
-        res = g_mkdir_with_parents (LOCALSTATEDIR "/run/ConsoleKit/inhibit",
+        res = g_mkdir_with_parents (RUNDIR "/ConsoleKit/inhibit",
                                     S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
         if (res < 0) {
                 g_warning ("Unable to create directory %s (%s)",
-                           LOCALSTATEDIR "/run/ConsoleKit/inhibit",
+                           RUNDIR "/ConsoleKit/inhibit",
                            g_strerror (errno));
 
                 return FALSE;
         }
 
-        if (g_chmod (LOCALSTATEDIR "/run/ConsoleKit/inhibit", 0755) == -1) {
+        if (g_chmod (RUNDIR "/ConsoleKit/inhibit", 0755) == -1) {
                 g_warning ("Failed to change permissions for %s",
-                           LOCALSTATEDIR "/run/ConsoleKit/inhibit");
+                           RUNDIR "/ConsoleKit/inhibit");
         }
 
         return TRUE;
@@ -391,8 +391,8 @@ get_named_pipe_path (const char* who)
 
         errno = 0;
 
-        path = g_strdup_printf ("%s/run/ConsoleKit/inhibit/inhibit.XXXXXX.pipe",
-                                LOCALSTATEDIR);
+        path = g_strdup_printf ("%s/ConsoleKit/inhibit/inhibit.XXXXXX.pipe",
+                                RUNDIR);
 
         /* check that we got a string */
         if (path == NULL) {

--- a/src/ck-manager.c
+++ b/src/ck-manager.c
@@ -202,8 +202,8 @@ ck_manager_dump (CkManager *manager)
 {
         int         fd;
         int         res;
-        const char *filename = LOCALSTATEDIR "/run/ConsoleKit/database";
-        const char *filename_tmp = LOCALSTATEDIR "/run/ConsoleKit/database~";
+        const char *filename = RUNDIR "/ConsoleKit/database";
+        const char *filename_tmp = RUNDIR "/ConsoleKit/database~";
 
         if (manager == NULL) {
                 g_warning ("ck_manager_dump: manager == NULL");
@@ -212,16 +212,16 @@ ck_manager_dump (CkManager *manager)
 
         /* always make sure we have a directory */
         errno = 0;
-        res = g_mkdir_with_parents (LOCALSTATEDIR "/run/ConsoleKit",
+        res = g_mkdir_with_parents (RUNDIR "/ConsoleKit",
                                     S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
         if (res < 0) {
                 g_warning ("Unable to create directory %s (%s)",
-                           LOCALSTATEDIR "/run/ConsoleKit",
+                           RUNDIR "/ConsoleKit",
                            g_strerror (errno));
                 return;
         }
 
-        g_debug ("ck_manager_dump: %s/run/ConsoleKit folder created", LOCALSTATEDIR);
+        g_debug ("ck_manager_dump: %s/ConsoleKit folder created", RUNDIR);
 
         fd = g_open (filename_tmp, O_CREAT | O_WRONLY, 0644);
         if (fd == -1) {

--- a/src/main.c
+++ b/src/main.c
@@ -186,7 +186,7 @@ delete_inhibit_files (void)
 {
         GDir *dir;
         GError *error = NULL;
-        const gchar *INHIBIT_DIRECTORY = LOCALSTATEDIR "/run/ConsoleKit/inhibit";
+        const gchar *INHIBIT_DIRECTORY = RUNDIR "/ConsoleKit/inhibit";
         const gchar *name;
 
         g_debug ("Cleaning up %s", INHIBIT_DIRECTORY);

--- a/tools/70-udev-acl.rules.in
+++ b/tools/70-udev-acl.rules.in
@@ -70,7 +70,7 @@ ENV{DDC_DEVICE}=="*?", TAG+="udev-acl"
 SUBSYSTEM=="usb", ENV{ID_MEDIA_PLAYER}=="?*", TAG+="udev-acl"
 
 # apply ACL for all locally logged in users
-LABEL="acl_apply", TAG=="udev-acl", TEST=="/var/run/ConsoleKit/database", \
+LABEL="acl_apply", TAG=="udev-acl", TEST=="@RUNDIR@/ConsoleKit/database", \
   RUN+="udev-acl --action=$env{ACTION} --device=$env{DEVNAME}"
 
 LABEL="acl_end"

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -45,6 +45,7 @@ AM_CFLAGS =							\
 	-DDATADIR=\""$(datadir)"\"				\
 	-DSYSCONFDIR=\""$(sysconfdir)"\" 			\
 	-DLOCALSTATEDIR=\""$(localstatedir)"\" 			\
+	-DRUNDIR=\""$(RUNDIR)"\" 			\
 	-DLOCALEDIR=\"$(localedir)\"		\
 	$(HISTORY_CFLAGS)					\
 	$(WARN_CFLAGS)						\

--- a/tools/udev-acl.c
+++ b/tools/udev-acl.c
@@ -132,7 +132,7 @@ static GSList *uids_with_local_active_session(const char *own_id)
         GKeyFile *keyfile;
 
         keyfile = g_key_file_new();
-        if (g_key_file_load_from_file(keyfile, "/var/run/ConsoleKit/database", 0, NULL)) {
+        if (g_key_file_load_from_file(keyfile, RUNDIR "/ConsoleKit/database", 0, NULL)) {
                 gchar **groups;
 
                 groups = g_key_file_get_groups(keyfile, NULL);


### PR DESCRIPTION
This allows use of /run on tmpfs instead of /var/run
without downstream symlink magic or patches.
