### PR TITLE
openbsd: unbreak get_kinfo_proc() by properly initializing len

### DIFF
--- a/src/ck-sysdeps-openbsd.c
+++ b/src/ck-sysdeps-openbsd.c
@@ -129,17 +129,13 @@ get_kinfo_proc (pid_t pid,
         size_t len;
 
         int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid,
-                      sizeof(struct kinfo_proc), 0 };
+                      sizeof(struct kinfo_proc), 1 };
 
 #ifndef nitems
 #define nitems(_a)      (sizeof((_a)) / sizeof((_a)[0]))
 #endif
 
-        if (sysctl(mib, nitems(mib), NULL, &len, NULL, 0) < 0)
-            return FALSE;
-
-        mib[5] = (len / sizeof(struct kinfo_proc));
-
+        len = sizeof(*p);
         if (sysctl(mib, nitems(mib), p, &len, NULL, 0) < 0)
             return FALSE;
 


### PR DESCRIPTION
No need to call sysctl(3) twice since we know exactly how many
structures it wants back: just one.