### PR TITLE
Respect multilib/multiarch filesystem layouts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -369,8 +369,8 @@ MAINTAINERCLEANFILES =			\
 
 install-data-local:
 	-mkdir -p $(DESTDIR)$(sysconfdir)/ConsoleKit/run-session.d
-	-mkdir -p $(DESTDIR)$(prefix)/lib/ConsoleKit/run-session.d
+	-mkdir -p $(DESTDIR)$(libdir)/ConsoleKit/run-session.d
 	-mkdir -p $(DESTDIR)$(sysconfdir)/ConsoleKit/run-seat.d
-	-mkdir -p $(DESTDIR)$(prefix)/lib/ConsoleKit/run-seat.d
+	-mkdir -p $(DESTDIR)$(libdir)/ConsoleKit/run-seat.d
 	-mkdir -p $(DESTDIR)$(RUNDIR)/ConsoleKit
 	-mkdir -p $(DESTDIR)$(localstatedir)/log/ConsoleKit

--- a/src/ck-manager.c
+++ b/src/ck-manager.c
@@ -1340,7 +1340,7 @@ do_restart (CkManager             *manager,
 
         data->manager = manager;
         data->context = context;
-        data->command = PREFIX "/lib/ConsoleKit/scripts/ck-system-restart";
+        data->command = LIBDIR "/ConsoleKit/scripts/ck-system-restart";
         data->event_type = CK_LOG_EVENT_SYSTEM_RESTART;
         data->description = "Restart";
         data->signal = PREPARE_FOR_SHUTDOWN;
@@ -1447,7 +1447,7 @@ do_stop (CkManager             *manager,
 
         data->manager = manager;
         data->context = context;
-        data->command = PREFIX "/lib/ConsoleKit/scripts/ck-system-stop";
+        data->command = LIBDIR "/ConsoleKit/scripts/ck-system-stop";
         data->event_type = CK_LOG_EVENT_SYSTEM_STOP;
         data->description = "Stop";
         data->signal = PREPARE_FOR_SHUTDOWN;
@@ -1702,7 +1702,7 @@ do_suspend (CkManager             *manager,
 
         data->manager = manager;
         data->context = context;
-        data->command = PREFIX "/lib/ConsoleKit/scripts/ck-system-suspend";
+        data->command = LIBDIR "/ConsoleKit/scripts/ck-system-suspend";
         data->event_type = CK_LOG_EVENT_SYSTEM_SUSPEND;
         data->description = "Suspend";
         data->signal = PREPARE_FOR_SLEEP;
@@ -1834,7 +1834,7 @@ do_hibernate (CkManager             *manager,
 
         data->manager = manager;
         data->context = context;
-        data->command = PREFIX "/lib/ConsoleKit/scripts/ck-system-hibernate";
+        data->command = LIBDIR "/ConsoleKit/scripts/ck-system-hibernate";
         data->event_type = CK_LOG_EVENT_SYSTEM_HIBERNATE;
         data->description = "Hibernate";
         data->signal = PREPARE_FOR_SLEEP;
@@ -1966,7 +1966,7 @@ do_hybrid_sleep (CkManager             *manager,
 
         data->manager = manager;
         data->context = context;
-        data->command = PREFIX "/lib/ConsoleKit/scripts/ck-system-hybridsleep";
+        data->command = LIBDIR "/ConsoleKit/scripts/ck-system-hybridsleep";
         data->event_type = CK_LOG_EVENT_SYSTEM_HIBERNATE;
         data->description = "Hybrid Sleep";
         data->signal = PREPARE_FOR_SLEEP;

--- a/tools/freebsd/Makefile.am
+++ b/tools/freebsd/Makefile.am
@@ -6,7 +6,7 @@ NULL =
 SUBDIRS = \
 	$(NULL)
 
-scriptdir = $(prefix)/lib/ConsoleKit/scripts
+scriptdir = $(libdir)/ConsoleKit/scripts
 script_SCRIPTS =			\
 	ck-system-stop			\
 	ck-system-restart		\

--- a/tools/linux/Makefile.am
+++ b/tools/linux/Makefile.am
@@ -6,7 +6,7 @@ NULL =
 SUBDIRS = \
 	$(NULL)
 
-scriptdir = $(prefix)/lib/ConsoleKit/scripts
+scriptdir = $(libdir)/ConsoleKit/scripts
 script_SCRIPTS =			\
 	ck-system-stop	\
 	ck-system-restart		\

--- a/tools/solaris/Makefile.am
+++ b/tools/solaris/Makefile.am
@@ -6,7 +6,7 @@ NULL =
 SUBDIRS = \
 	$(NULL)
 
-scriptdir = $(prefix)/lib/ConsoleKit/scripts
+scriptdir = $(libdir)/ConsoleKit/scripts
 script_SCRIPTS =			\
 	ck-system-stop			\
 	ck-system-restart		\


### PR DESCRIPTION
Adapted from <https://bugs.freedesktop.org/show_bug.cgi?id=24608>.

This patch fixes the execution paths and install locations for scripts, and installs them to the correct arch-dependent location. On that bug, supposedly there was some sort of issue doing that, but there have been no reports of issues with the patch on the distribution I am adapting this for ConsoleKit2 on: Exherbo Linux.