### PR TITLE
Fix two install issues with 90-consolekit

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -113,8 +113,7 @@ install-logrotate: $(LOGROTATE_CONFS)
 
 install-90-consolekit: $(XINITRC_CONFS)
 	$(MKDIR_P) $(DESTDIR)$(XINITRC_DIR)/
-	$(INSTALL_PROGRAM) 90-consolekit $(DESTDIR)$(XINITRC_DIR) && \
-		chmod +x $(DESTDIR)$(XINITRC_DIR)/90-consolekit
+	$(INSTALL_SCRIPT) 90-consolekit $(DESTDIR)$(XINITRC_DIR)
 
 uninstall-logrotate:
 	rm -f $(DESTDIR)$(sysconfdir)/logrotate.d/consolekit


### PR DESCRIPTION
* Don't try to run "chmod +x" on 90-consolekit, it is not a executable.
* Use INSTALL_SCRIPT instead of INSTALL_PROGRAM. According to a comment
  in the header of 90-consolekit this file is sourced by Xsession(5), not
  executed. Now it also doesn't try to run strip on the 90-consolekit file.