### PR TITLE
Fix some libdir/scripts stuff missed in 4d87a25ea0af

### DIFF
--- a/src/ck-seat.c
+++ b/src/ck-seat.c
@@ -1443,7 +1443,7 @@ ck_seat_run_programs (CkSeat    *seat,
         g_assert(n <= G_N_ELEMENTS(extra_env));
 
         ck_run_programs (SYSCONFDIR "/ConsoleKit/run-seat.d", action, extra_env);
-        ck_run_programs (PREFIX "/lib/ConsoleKit/run-seat.d", action, extra_env);
+        ck_run_programs (LIBDIR "/ConsoleKit/run-seat.d", action, extra_env);
 
         for (n = 0; extra_env[n] != NULL; n++) {
                 g_free (extra_env[n]);

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -171,9 +171,9 @@ udev_acl_CFLAGS =       \
 	$(NULL)
 
 install-exec-hook:
-	mkdir -p $(DESTDIR)$(prefix)/lib/ConsoleKit/run-seat.d
+	mkdir -p $(DESTDIR)$(libdir)/ConsoleKit/run-seat.d
 	mkdir -p $(DESTDIR)$(UDEVDIR)
-	ln -sf $(libexecdir)/udev-acl $(DESTDIR)$(prefix)/lib/ConsoleKit/run-seat.d/udev-acl.ck
+	ln -sf $(libexecdir)/udev-acl $(DESTDIR)$(libdir)/ConsoleKit/run-seat.d/udev-acl.ck
 	ln -sf $(libexecdir)/udev-acl $(DESTDIR)$(UDEVDIR)/udev-acl
 endif
 


### PR DESCRIPTION
Assuming 4d87a25ea0af is a desired commit, then it appears to miss the contents of this patch.
I've not tested anything later than 0.9.5 yet, so I have no data yet to support either conclusion.