### PR TITLE
Apply overlooked PREFIX/lib -> LIBDIR substitution

### DIFF
--- a/src/ck-session.c
+++ b/src/ck-session.c
@@ -1273,7 +1273,7 @@ ck_session_run_programs (CkSession  *session,
         g_assert(n <= G_N_ELEMENTS(extra_env));
 
         ck_run_programs (SYSCONFDIR "/ConsoleKit/run-session.d", action, extra_env);
-        ck_run_programs (PREFIX "/lib/ConsoleKit/run-session.d", action, extra_env);
+        ck_run_programs (LIBDIR "/ConsoleKit/run-session.d", action, extra_env);
 
         for (n = 0; extra_env[n] != NULL; n++) {
                 g_free (extra_env[n]);


### PR DESCRIPTION
This edit was overlooked in commit b045a4245199b12dfc04f03b22bc1e9b1f80aae9 and it breaks console-kit-daemon.