### PR TITLE
Fix undefined behavior

### DIFF
--- a/src/ck-log-event.h
+++ b/src/ck-log-event.h
@@ -140,7 +140,7 @@ typedef struct
 {
         union {
                 CkLogNoneEvent none;
-                CkLogSystemRestartEvent system_start;
+                CkLogSystemStartEvent system_start;
                 CkLogSystemStopEvent system_stop;
                 CkLogSystemRestartEvent system_restart;
                 CkLogSeatAddedEvent seat_added;

--- a/tools/ck-log-system-start.c
+++ b/tools/ck-log-system-start.c
@@ -249,7 +249,7 @@ main (int    argc,
 
         event.type = CK_LOG_EVENT_SYSTEM_START;
         g_get_current_time (&event.timestamp);
-        e = (CkLogSystemStartEvent *) &event;
+        e = (CkLogSystemStartEvent *) &event.event;
 
         if (uname (&uts) == 0) {
                 e->kernel_release = uts.release;


### PR DESCRIPTION
It is unlikely that ck-log-system-start would crash because of this, but
still it is better to have it fixed.