### PR TITLE
When assigning session to active VT prefer graphical sessions

### DIFF
--- a/src/ck-seat.c
+++ b/src/ck-seat.c
@@ -536,9 +536,9 @@ find_session_for_display_device (CkSeat     *seat,
         GList     *sessions;
         CkSession *session;
 
-        sessions = find_sessions_for_display_device (seat, device);
+        sessions = find_sessions_for_x11_display_device (seat, device);
         if (sessions == NULL) {
-                sessions = find_sessions_for_x11_display_device (seat, device);
+                sessions = find_sessions_for_display_device (seat, device);
         }
 
         if (sessions == NULL) {


### PR DESCRIPTION
I case when we launch graphical session on top of text session on the
same VT we want to mark newly created graphical session as active.