### PR TITLE
More cgroup functionality

### DIFF
--- a/src/ck-process-group.c
+++ b/src/ck-process-group.c
@@ -223,7 +223,7 @@ ck_process_group_create (CkProcessGroup *pgroup,
          * to clean up the cgroup after all the processes are gone which
          * will happen when the user logs out.
          */
-        ret = cgmanager_create_sync (NULL, priv->cgmanager_proxy, "cpuacct", ssid, &existed);
+        ret = cgmanager_create_sync (NULL, priv->cgmanager_proxy, "all", ssid, &existed);
         if (ret != 0) {
                 /* TRANSLATORS: Please ensure you keep the %s in the
                  * string somewhere. It's the detailed error message from
@@ -233,7 +233,7 @@ ck_process_group_create (CkProcessGroup *pgroup,
                 return FALSE;
         }
 
-        ret = cgmanager_move_pid_abs_sync (NULL, priv->cgmanager_proxy, "cpuacct", ssid, process);
+        ret = cgmanager_move_pid_abs_sync (NULL, priv->cgmanager_proxy, "all", ssid, process);
         if (ret != 0) {
                 /* TRANSLATORS: Please ensure you keep the %s in the
                  * string somewhere. It's the detailed error message from
@@ -243,7 +243,7 @@ ck_process_group_create (CkProcessGroup *pgroup,
                 return FALSE;
         }
 
-        ret = cgmanager_remove_on_empty_sync (NULL, priv->cgmanager_proxy, "cpuacct", ssid);
+        ret = cgmanager_remove_on_empty_sync (NULL, priv->cgmanager_proxy, "all", ssid);
         if (ret != 0) {
                 /* TRANSLATORS: Please ensure you keep the %s in the
                  * string somewhere. It's the detailed error message from


### PR DESCRIPTION
- Creates cgroups on all controllers
- Chown each new cgroup to the progress group's leader's uid.

One thing to note: `cgmanager_create` treats its input *relative* to the "current" root, i.e. calling it with '/baz' while already being constrained in the cgroup '/foo/bar', will create the new cgroup '/foo/bar/baz', *not* the cgroup '/baz'.

So as a warning:
Hilarity ensues when combining consolekit2, openrc, and cgmanager without making cgmanager ignore the openrc cgroup controller, as in that particular constellation, the new cgroup for the openrc controller will be created below `/sys/fs/cgroup/openrc/dbus/`, making the later `cgmanager_movepid_abs` fail (obviously).

Disregarding that minor (?) issue, on Funtoo (Gentoo derivative) this PR together with sddm 0.13, `session		optional pam_ck_connector.so` in `/etc/pam.d/sddm-greeter` and `eval exec ck-launch-session "$session"` in `/usr/share/sddm/scripts/Xsession` gets me this in my terminal emulator (with :

```
cat /proc/self/cgroup 
13:name=systemd:/org/freedesktop/ConsoleKit/Session3
12:hugetlb:/org/freedesktop/ConsoleKit/Session3
11:net_prio:/org/freedesktop/ConsoleKit/Session3
10:perf_event:/org/freedesktop/ConsoleKit/Session3
9:net_cls:/org/freedesktop/ConsoleKit/Session3
8:freezer:/org/freedesktop/ConsoleKit/Session3
7:devices:/org/freedesktop/ConsoleKit/Session3
6:memory:/org/freedesktop/ConsoleKit/Session3
5:blkio:/org/freedesktop/ConsoleKit/Session3
4:cpuacct:/org/freedesktop/ConsoleKit/Session3
3:cpu:/org/freedesktop/ConsoleKit/Session3/foo/bar
2:cpuset:/org/freedesktop/ConsoleKit/Session3
1:name=openrc:/xdm

ls -a /sys/fs/cgroup/perf_event/org/freedesktop/ConsoleKit/Session3
drwxr-xr-x 2 cal  cal  0 Feb  2 01:47 ./
drwxr-xr-x 5 root root 0 Feb  2 01:47 ../
-rw-r--r-- 1 root root 0 Feb  2 01:47 notify_on_release
-rw-r--r-- 1 cal  cal  0 Feb  2 01:47 tasks
-rw-r--r-- 1 root root 0 Feb  2 01:47 cgroup.clone_children
-rw-r--r-- 1 cal  cal  0 Feb  2 01:47 cgroup.procs
```