### PR TITLE
Fixes for Issue #65 ck-1.1.0 cgroups warning

### DIFF
--- a/src/ck-process-group.c
+++ b/src/ck-process-group.c
@@ -255,11 +255,9 @@ ck_process_group_create (CkProcessGroup *pgroup,
 
         ret = cgmanager_move_pid_abs_sync (NULL, priv->cgmanager_proxy, "all", ssid, process);
         if (ret != 0) {
-                /* TRANSLATORS: Please ensure you keep the %s in the
-                 * string somewhere. It's the detailed error message from
-                 * cgmanager.
-                 */
-                throw_nih_warning (_("Failed to move the session leader process to cgroup, the error was: %s"));
+                NihError *nerr = nih_error_get ();
+                g_debug ("Failed to move the session leader process to cgroup, the error was: %s", nerr->message);
+                nih_free (nerr);
 
                 /* We failed to move the process into all the cgroups, but
                  * we really only require the cpuacct for our internal use.

--- a/src/ck-sysdeps-unix.c
+++ b/src/ck-sysdeps-unix.c
@@ -409,11 +409,6 @@ ck_generate_runtime_dir_for_user (guint uid)
 
         TRACE ();
 
-        if (uid < 1) {
-                g_debug ("We do not create runtime dirs for root");
-                return NULL;
-        }
-
         errno = 0;
         pwent = getpwuid (uid);
         if (pwent == NULL) {

--- a/tools/ck-remove-directory.c
+++ b/tools/ck-remove-directory.c
@@ -51,11 +51,6 @@ become_user (uid_t uid, const gchar* dest)
         int            res;
         struct passwd *pwent;
 
-        if (uid < 1) {
-                g_critical ("invalid UID");
-                exit (1);
-        }
-
         if (dest == NULL) {
                 g_critical ("invalid dest");
                 exit (1);
@@ -145,11 +140,6 @@ main (int    argc,
         if (! ret) {
                 g_warning ("%s", error->message);
                 g_error_free (error);
-                exit (1);
-        }
-
-        if (user_id < 1) {
-                g_warning ("Invalid UID");
                 exit (1);
         }
 


### PR DESCRIPTION
First remove the restriction where we don't create an XDG_RUNTIME_DIR for root so programs run with sudo/pkexec don't write to random locations because their fallback code is broken.

Second, if we fail when calling cgmanager_move_pid_abs_sync for the "all" cgroup, we'll still log the warning but try again with cgmanager_move_pid_abs_sync "cpuacct" which seems to always work.

These are fixes for https://github.com/ConsoleKit2/ConsoleKit2/issues/65