### PR TITLE
ck-remove-directory: remove dest dir as real user

### DIFF
--- a/tools/ck-remove-directory.c
+++ b/tools/ck-remove-directory.c
@@ -153,7 +153,5 @@ main (int    argc,
 
         become_user (user_id, dest);
 
-        ret = remove_dest_dir (dest);
-
-        return ret != TRUE;
+        return remove_dest_dir (dest) == 0 ? 0 : 1;
 }

--- a/tools/ck-remove-directory.c
+++ b/tools/ck-remove-directory.c
@@ -46,15 +46,10 @@
 
 
 static void
-become_user (uid_t uid, const gchar* dest)
+become_user (uid_t uid)
 {
         int            res;
         struct passwd *pwent;
-
-        if (dest == NULL) {
-                g_critical ("invalid dest");
-                exit (1);
-        }
 
         errno = 0;
         pwent = getpwuid (uid);
@@ -151,7 +146,7 @@ main (int    argc,
                 exit (1);
         }
 
-        become_user (user_id, dest);
+        become_user (user_id);
 
         return remove_dest_dir (dest) == 0 ? 0 : 1;
 }

--- a/tools/ck-remove-directory.c
+++ b/tools/ck-remove-directory.c
@@ -60,17 +60,17 @@ become_user (uid_t uid)
 
         /* set the group */
         errno = 0;
-        res = setgid (pwent->pw_gid);
+        res = setegid (pwent->pw_gid);
         if (res == -1) {
-                g_warning ("Error performing setgid: %s", g_strerror (errno));
+                g_warning ("Error performing setegid: %s", g_strerror (errno));
                 exit (1);
         }
 
         /* become the user */
         errno = 0;
-        res = setuid (uid);
+        res = seteuid (uid);
         if (res == -1) {
-                g_warning ("Error performing setuid: %s", g_strerror (errno));
+                g_warning ("Error performing seteuid: %s", g_strerror (errno));
                 exit (1);
         }
 }
@@ -81,7 +81,7 @@ unlink_cb (const char        *fpath,
            int                typeflag,
            struct FTW        *ftwbuf)
 {
-        int ret = remove (fpath);
+        int ret = ftwbuf->level > 0 ? remove (fpath) : 0;
 
         if (ret) {
                 g_error ("Failed to remove %s, reason was: %s", fpath, strerror(errno));
@@ -94,7 +94,26 @@ unlink_cb (const char        *fpath,
 static int
 remove_dest_dir (const gchar *dest)
 {
-        return nftw(dest, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+        int ret;
+
+        if (ret = nftw(dest, unlink_cb, 64, FTW_DEPTH | FTW_PHYS)) {
+                return ret;
+        }
+
+        errno = 0;
+        ret = seteuid (getuid ());
+        if (ret == -1) {
+                g_warning ("Error performing seteuid: %s", g_strerror (errno));
+                exit (1);
+        }
+
+        ret = remove (dest);
+        if (ret) {
+                g_error ("Failed to remove %s, reason was: %s", dest, strerror (errno));
+                errno = 0;
+        }
+
+        return ret;
 }
 
 int


### PR DESCRIPTION
Attempting to remove `<rundir>/user/<uid>` as user `<uid>` fails because the user typically does not own the `<rundir>/user` directory. This failure causes `remove_dest_dir()` to call `g_error()`, which raises a SIGTRAP. This causes a trap diagnostic message to be emitted to the kernel log, which is undesirable.

This pull request changes `remove_dest_dir()` so that it removes the contents of the dest dir as user `<uid>` and then removes the dest dir itself as the real user invoking `ck-remove-directory` (probably root). This pull request also includes two other minor cleanup commits.

Current (existing) behavior causes messages like this in the kernel log whenever a ConsoleKit session ends:

```
traps: ck-remove-direc[23119] trap int3 ip:7f5d94016750 sp:7ffc5a95fd90 error:0
```

And further, the `/var/run/user/<uid>` directory is *emptied* but is not *removed*, due to insufficient permission. The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) states:

> …if the user fully logs out the directory MUST be removed.

Thus, `ck-remove-directory`, as it stands, is not compliant with the specification.

This pull request brings `ck-remove-directory` into compliance by correctly removing the directory (after regaining the necessary privileges).