### PR TITLE
Selinux support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -302,6 +302,25 @@ AS_IF([test "x$have_cgmanager" = "xyes"], [
 AM_CONDITIONAL([HAVE_CGMANAGER], [test "x$have_cgmanager" = "xyes"])
 AC_SUBST(HAVE_CGMANAGER)
 
+# selinux
+have_selinux=no
+AC_ARG_ENABLE([selinux],
+  AS_HELP_STRING([--enable-selinux], [Enable selinux support @<:@default=auto@:>@]),
+  [enable_selinux=$enableval],
+  [enable_selinux=auto])
+AS_IF([test "x$enable_selinux" != "xno"], [
+  PKG_CHECK_MODULES([SELINUX], [libselinux], [have_selinux=yes], [have_selinux=no])
+  if test "x$enable_selinux" = "xyes" -a "x$have_selinux" = "xno"; then
+    AC_MSG_ERROR([selinux support explicitly requested but dependencies not found])
+  fi
+])
+AS_IF([test "x$have_selinux" = "xyes"], [
+  AC_DEFINE([HAVE_SELINUX], [], [Define if we have selinux])
+])
+AM_CONDITIONAL([HAVE_SELINUX], [test "x$have_selinux" = "xyes"])
+AC_SUBST(HAVE_SELINUX)
+AC_SUBST(SELINUX_LIBS)
+
 dnl ------------------------------------------------------------------------------
 dnl udev-acl - apply ACLs for users with local forground sessions
 dnl ------------------------------------------------------------------------------
@@ -583,6 +602,7 @@ echo "
         Build PAM module:         ${msg_pam_module}
         Build udev-acl:           ${enable_udev_acl}
         cgroup support:           ${have_cgmanager}
+        SELinux support:          ${have_selinux}
         Build docs:               ${enable_docbook_docs}
         xinitrc dir:              ${XINITRC_DIR}
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,6 +50,7 @@ if CK_COMPILE_LINUX
 libck_la_SOURCES +=		\
 	ck-sysdeps-linux.c	\
 	$(NULL)
+libck_la_LIBADD += $(SELINUX_LIBS)
 endif
 if CK_COMPILE_SOLARIS
 libck_la_SOURCES +=		\

--- a/src/ck-sysdeps-freebsd.c
+++ b/src/ck-sysdeps-freebsd.c
@@ -655,3 +655,14 @@ ck_remove_tmpfs (guint uid, const gchar *dest)
 
         return FALSE;
 }
+
+gboolean
+ck_sysdeps_init (void)
+{
+        return TRUE;
+}
+
+void
+ck_sysdeps_fini (void)
+{
+}

--- a/src/ck-sysdeps-gnu.c
+++ b/src/ck-sysdeps-gnu.c
@@ -433,3 +433,14 @@ ck_remove_tmpfs (guint uid, const gchar *dest)
 {
         return FALSE;
 }
+
+gboolean
+ck_sysdeps_init (void)
+{
+        return TRUE;
+}
+
+void
+ck_sysdeps_fini (void)
+{
+}

--- a/src/ck-sysdeps-linux.c
+++ b/src/ck-sysdeps-linux.c
@@ -998,14 +998,22 @@ ck_make_tmpfs (guint uid, guint gid, const gchar *dest)
 {
 #ifdef HAVE_SYS_MOUNT_H
         gchar        *opts;
+        gchar        *context;
         int           result;
 
         TRACE ();
 
-        opts = g_strdup_printf ("mode=0700,uid=%d", uid);
+        context = ck_selinux_lookup_context(dest);
+        if (context) {
+                opts = g_strdup_printf ("mode=0700,uid=%d,rootcontext=%s", uid, context);
+        } else {
+                opts = g_strdup_printf ("mode=0700,uid=%d", uid);
+        }
 
+        g_debug ("mounting tmpfs. uid=%d, gid=%d, dest=%s, opts=%s", uid, gid, dest, opts);
         result = mount("none", dest, "tmpfs", 0, opts);
 
+        g_free (context);
         g_free (opts);
 
         if (result == 0) {

--- a/src/ck-sysdeps-linux.c
+++ b/src/ck-sysdeps-linux.c
@@ -1173,3 +1173,15 @@ ck_wait_for_console_switch (gint sys_fd, gint32 *num)
         return new_vt < 0 ? FALSE : TRUE;
 }
 #endif /* HAVE_SYS_VT_SIGNAL */
+
+gboolean
+ck_sysdeps_init (void)
+{
+        return ck_selinux_open();
+}
+
+void
+ck_sysdeps_fini (void)
+{
+        ck_selinux_close();
+}

--- a/src/ck-sysdeps-netbsd.c
+++ b/src/ck-sysdeps-netbsd.c
@@ -530,3 +530,14 @@ ck_remove_tmpfs (guint uid, const gchar *dest)
 
         return FALSE;
 }
+
+gboolean
+ck_sysdeps_init (void)
+{
+        return TRUE;
+}
+
+void
+ck_sysdeps_fini (void)
+{
+}

--- a/src/ck-sysdeps-openbsd.c
+++ b/src/ck-sysdeps-openbsd.c
@@ -540,3 +540,14 @@ ck_remove_tmpfs (guint uid, const gchar *dest)
 
         return FALSE;
 }
+
+gboolean
+ck_sysdeps_init (void)
+{
+        return TRUE;
+}
+
+void
+ck_sysdeps_fini (void)
+{
+}

--- a/src/ck-sysdeps-solaris.c
+++ b/src/ck-sysdeps-solaris.c
@@ -562,3 +562,14 @@ ck_remove_tmpfs (guint uid, const gchar *dest)
 {
         return FALSE;
 }
+
+gboolean
+ck_sysdeps_init (void)
+{
+        return TRUE;
+}
+
+void
+ck_sysdeps_fini (void)
+{
+}

--- a/src/ck-sysdeps.h
+++ b/src/ck-sysdeps.h
@@ -29,6 +29,9 @@ G_BEGIN_DECLS
 
 typedef struct _CkProcessStat CkProcessStat;
 
+gboolean     ck_sysdeps_init                  (void);
+void         ck_sysdeps_fini                  (void);
+
 gboolean     ck_process_stat_new_for_unix_pid (pid_t           pid,
                                                CkProcessStat **stat,
                                                GError        **error);

--- a/src/main.c
+++ b/src/main.c
@@ -63,6 +63,8 @@ bus_acquired (GDBusConnection *connection,
 
         g_debug ("bus_acquired %s\n", name);
 
+        ck_sysdeps_init();
+
         manager = ck_manager_new (connection);
 
         if (manager == NULL) {
@@ -84,6 +86,8 @@ name_lost (GDBusConnection *connection,
            gpointer user_data)
 {
         g_debug ("name_lost\n");
+
+        ck_sysdeps_fini();
 
         /* Release the  object */
         g_debug ("Disconnected from D-Bus");


### PR DESCRIPTION
This adds support to CK for SELinux. It gets the correct label from the system policy and correctly labels the /run/user/ tmpfs mounts by adding a rootcontext= option. I have already added all the required policy changes to both the gentoo and upstream ReferencePolicy.

I currently call ck_open_selinux from within the lookup label function. Ideally ck_selinux_open should be called when the daemon starts and ck_selinux_close when it is stopping but I am not entirely sure where that should be done. I can re-do the patches and move those calls somewhere better.