### PR TITLE
Fix a reversed condition for invalid device on NetBSD

### DIFF
--- a/src/ck-sysdeps-netbsd.c
+++ b/src/ck-sysdeps-netbsd.c
@@ -121,7 +121,7 @@ ck_process_stat_get_tty (CkProcessStat *stat)
 {
         g_return_val_if_fail (stat != NULL, NULL);
 
-        if (stat->tty != NODEV){
+        if (stat->tty == NODEV){
                 return NULL;
         }
 


### PR DESCRIPTION
It's my fault, and it is nice to merge to 1.0 branch too.