### PR TITLE
Use UID of logged in user as cgroup owner instead UID of session leader process

### DIFF
--- a/src/ck-manager.c
+++ b/src/ck-manager.c
@@ -2808,7 +2808,8 @@ open_session_for_leader (CkManager             *manager,
         pgroup = ck_process_group_get ();
         ck_process_group_create (pgroup,
                                  ck_session_leader_get_pid (leader),
-                                 ssid);
+                                 ssid,
+                                 unix_user);
 
         g_hash_table_insert (manager->priv->sessions,
                              g_strdup (ssid),

--- a/src/ck-process-group.c
+++ b/src/ck-process-group.c
@@ -207,7 +207,8 @@ ck_process_group_finalize (GObject *object)
 gboolean
 ck_process_group_create (CkProcessGroup *pgroup,
                          pid_t process,
-                         const gchar *ssid)
+                         const gchar *ssid,
+                         guint unix_user)
 {
 #ifdef HAVE_CGMANAGER
         CkProcessGroupPrivate *priv = CK_PROCESS_GROUP_GET_PRIVATE (pgroup);
@@ -237,7 +238,7 @@ ck_process_group_create (CkProcessGroup *pgroup,
         }
 
         errno = 0;
-        pwent = getpwuid (ck_unix_pid_get_uid(process));
+        pwent = getpwuid (unix_user);
         if (pwent == NULL) {
                 g_warning ("Unable to lookup UID: %s", g_strerror (errno));
                 return FALSE;

--- a/src/ck-process-group.h
+++ b/src/ck-process-group.h
@@ -59,7 +59,8 @@ CkProcessGroup   *ck_process_group_get              (void);
 
 gboolean          ck_process_group_create           (CkProcessGroup *pgroup,
                                                      pid_t process,
-                                                     const gchar *ssid);
+                                                     const gchar *ssid,
+                                                     guint unix_user);
 
 gchar            *ck_process_group_get_ssid         (CkProcessGroup *pgroup,
                                                      pid_t process);


### PR DESCRIPTION
Owner of session leader process in most cases is root.