### PR TITLE
OpenBSD: adapt to recent kvm(3) restrictions

### DIFF
--- a/src/ck-sysdeps-openbsd.c
+++ b/src/ck-sysdeps-openbsd.c
@@ -256,7 +256,7 @@ ck_unix_pid_get_env_hash (pid_t pid)
         struct kinfo_proc p;
         int               i;
 
-        kd = kvm_openfiles (NULL, NULL, NULL, O_RDONLY, errbuf);
+        kd = kvm_openfiles (NULL, NULL, NULL, KVM_NO_FILES, errbuf);
         if (kd == NULL) {
 		g_warning ("kvm_openfiles failed: %s", errbuf);
                 return NULL;


### PR DESCRIPTION
OpenBSD no longer allows accessing /dev/mem via kvm(3) so change
the kvm_openfiles(3) flag from O_RDONLY to KVM_NO_FILES; actually
it should have been this way since the beginning and matches what
NetBSD does.