### PR TITLE
Add ListSeats method to Manager interface

### DIFF
--- a/data/ConsoleKit.conf
+++ b/data/ConsoleKit.conf
@@ -80,6 +80,9 @@
            send_member="CloseSession"/>
     <allow send_destination="org.freedesktop.ConsoleKit"
            send_interface="org.freedesktop.ConsoleKit.Manager"
+           send_member="ListSeats"/>
+    <allow send_destination="org.freedesktop.ConsoleKit"
+           send_interface="org.freedesktop.ConsoleKit.Manager"
            send_member="GetSeats"/>
     <allow send_destination="org.freedesktop.ConsoleKit"
            send_interface="org.freedesktop.ConsoleKit.Manager"

--- a/src/org.freedesktop.ConsoleKit.Manager.xml
+++ b/src/org.freedesktop.ConsoleKit.Manager.xml
@@ -531,6 +531,24 @@
       </doc:doc>
     </method>
 
+    <method name="ListSeats">
+      <arg name="seats" direction="out" type="a(so)">
+        <doc:doc>
+          <doc:summary>an array of seat names and IDs</doc:summary>
+        </doc:doc>
+      </arg>
+      <doc:doc>
+        <doc:description>
+          <doc:para>Retrieves a list of all <doc:ref type="interface" to="Seat">Seats</doc:ref>
+          that are present on the system.</doc:para>
+          <doc:para>Like the logind method of the same name, this returns both the seat's name
+          (such as "seat0") and the D-Bus object path for the seat object that implements the
+          <doc:ref type="interface" to="Seat">Seat</doc:ref> interface.</doc:para>
+        </doc:description>
+        <doc:seealso><doc:ref type="method" to="Manager.GetSeats">GetSeats()</doc:ref></doc:seealso>
+      </doc:doc>
+    </method>
+
     <method name="GetSeats">
       <arg name="seats" direction="out" type="ao">
         <doc:doc>


### PR DESCRIPTION
This adds a logind-compatible ListSeats method to the ConsoleKit.Manager
interface.  This is needed because the seat name does not always exactly
map to the object path (for instance, /Seat1 is 'seat0').

This also allows SDDM to work properly with ConsoleKit2.

Theoretically, this closes #99; but SDDM needs a further patch to properly call CK2 (bug in their code adds wrong / to interface class name).

I did not add anything to the test suite as I wasn't sure where to put it nor what should be tested.  With further guidance, I would be willing to do so.