### PR TITLE
Fix `make_tmpfs` on DragonFly and clean up some redundant code

### DIFF
--- a/src/ck-sysdeps-dragonfly.c
+++ b/src/ck-sysdeps-dragonfly.c
@@ -476,70 +476,22 @@ ck_get_active_console_num (int    console_fd,
         return ret;
 }
 
-static gchar *
-get_string_sysctl (GError **err, const gchar *format, ...)
-{
-        va_list args;
-        gchar *name;
-        size_t value_len;
-        gchar *str = NULL;
-
-        g_return_val_if_fail(format != NULL, FALSE);
-
-        va_start (args, format);
-        name = g_strdup_vprintf (format, args);
-        va_end (args);
-
-        if (sysctlbyname (name, NULL, &value_len, NULL, 0) == 0) {
-                str = g_new (char, value_len + 1);
-                if (sysctlbyname (name, str, &value_len, NULL, 0) == 0) {
-                        str[value_len] = 0;
-                } else {
-                        g_free (str);
-                        str = NULL;
-                }
-        }
-
-        if (!str)
-                g_set_error (err, 0, 0, "%s", g_strerror(errno));
-
-        g_free(name);
-        return str;
-}
-
-static gboolean
-freebsd_supports_sleep_state (const gchar *state)
-{
-        gboolean ret = FALSE;
-        gchar *sleep_states;
-
-        sleep_states = get_string_sysctl (NULL, "hw.acpi.supported_sleep_state");
-        if (sleep_states != NULL) {
-                if (strstr (sleep_states, state) != NULL)
-                        ret = TRUE;
-        }
-
-        g_free (sleep_states);
-
-        return ret;
-}
-
+/* DragonFly has no support for suspend, hibernate, or sleep */
 gboolean
 ck_system_can_suspend (void)
 {
-        return freebsd_supports_sleep_state ("S3");
+        return FALSE;
 }
 
 gboolean
 ck_system_can_hibernate (void)
 {
-        return freebsd_supports_sleep_state ("S4");
+        return FALSE;
 }
 
 gboolean
 ck_system_can_hybrid_sleep (void)
 {
-        /* TODO: not implemented */
         return FALSE;
 }
 

--- a/src/ck-sysdeps-dragonfly.c
+++ b/src/ck-sysdeps-dragonfly.c
@@ -48,6 +48,7 @@
 #ifdef HAVE_SYS_MOUNT_H
 #include <sys/mount.h>
 #endif
+#include <vfs/tmpfs/tmpfs_mount.h>
 
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
@@ -546,16 +547,19 @@ gboolean
 ck_make_tmpfs (guint uid, guint gid, const gchar *dest)
 {
 #ifdef HAVE_SYS_MOUNT_H
-        gchar        *opts;
-        int           result;
-
+        int                     result;
+        struct tmpfs_mount_info opts;
         TRACE ();
 
-        opts = g_strdup_printf ("mode=0700,uid=%d", uid);
+        opts.ta_version = TMPFS_ARGS_VERSION;
+        opts.ta_size_max = 0;
+        opts.ta_nodes_max = 0;
+        opts.ta_maxfsize_max = 0;
+        opts.ta_root_uid = uid;
+        opts.ta_root_gid = gid;
+        opts.ta_root_mode = 0x1c0; /* 0700 */
 
-        result = mount("tmpfs", dest, 0, opts);
-
-        g_free (opts);
+        result = mount("tmpfs", dest, 0, &opts);
 
         if (result == 0) {
                 return TRUE;


### PR DESCRIPTION
This PR now properly fixes `make_tmpfs` on DragonFly by passing a struct to `mount(2)`, not a string (which is not supported on DragonFly).

Without this patch per-user tmpfs' were created with invalid ownership and mode and were hence not usable (unless one went in as root and corrected ownership and mode).

For this code to build you have to use either the current `master` branch of DragonFly or wait for the imminent 5.1 release, as the headers containing the `tmpfs_mount_info` script were not previously installed in a DragonFly system.