### PR TITLE
add init support to shutdown commands

### DIFF
--- a/tools/linux/ck-system-restart
+++ b/tools/linux/ck-system-restart
@@ -5,12 +5,20 @@ SHUTDOWN_CMD=shutdown
 SHUTDOWN_CMD_ARGS='-r now'
 
 # Check based on init
-if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
-	SHUTDOWN_CMD=openrc-shutdown
-elif [ "$(ps -p 1 -o comm=)" = runit ]; then
-	SHUTDOWN_CMD=runit-init
-	SHUTDOWN_CMD_ARGS="6"
-fi
+case "$(ps -p 1 -o comm=)" in
+	openrc-init)
+		SHUTDOWN_CMD=openrc-shutdown
+		SHUTDOWN_CMD_ARGS='-r now'
+	;;
+	runit)
+		SHUTDOWN_CMD=runit-init
+		SHUTDOWN_CMD_ARGS="6"
+	;;
+	*)
+		SHUTDOWN_CMD=shutdown
+		SHUTDOWN_CMD_ARGS='-r now'
+	;;
+esac
 
 if [ -x "/sbin/${SHUTDOWN_CMD}" ] ; then
 	/sbin/${SHUTDOWN_CMD} ${SHUTDOWN_CMD_ARGS}

--- a/tools/linux/ck-system-restart
+++ b/tools/linux/ck-system-restart
@@ -12,6 +12,7 @@ case "$(ps -p 1 -o comm=)" in
 		SHUTDOWN_CMD_ARGS="6"
 	;;
 	*)
+		# sysvinit compatible
 		SHUTDOWN_CMD=shutdown
 		SHUTDOWN_CMD_ARGS='-r now'
 	;;

--- a/tools/linux/ck-system-restart
+++ b/tools/linux/ck-system-restart
@@ -1,9 +1,6 @@
 #!/bin/sh
 # ck-system-restart
 
-SHUTDOWN_CMD=shutdown
-SHUTDOWN_CMD_ARGS='-r now'
-
 # Check based on init
 case "$(ps -p 1 -o comm=)" in
 	openrc-init)

--- a/tools/linux/ck-system-restart
+++ b/tools/linux/ck-system-restart
@@ -7,8 +7,7 @@ SHUTDOWN_CMD_ARGS='-r now'
 # Check based on init
 if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
 	SHUTDOWN_CMD=openrc-shutdown
-fi
-if [ "$(ps -p 1 -o comm=)" = runit-init ]; then
+elif [ "$(ps -p 1 -o comm=)" = runit-init ]; then
 	SHUTDOWN_CMD=runit-init
 	SHUTDOWN_CMD_ARGS="6"
 fi

--- a/tools/linux/ck-system-restart
+++ b/tools/linux/ck-system-restart
@@ -1,11 +1,23 @@
 #!/bin/sh
+# ck-system-restart
 
-#Try for common tools
-if [ -x "/sbin/shutdown" ] ; then
-	/sbin/shutdown -r now
+SHUTDOWN_CMD=shutdown
+SHUTDOWN_CMD_ARGS='-r now'
+
+# Check based on init
+if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
+	SHUTDOWN_CMD=openrc-shutdown
+fi
+if [ "$(ps -p 1 -o comm=)" = runit-init ]; then
+	SHUTDOWN_CMD=runit-init
+	SHUTDOWN_CMD_ARGS="6"
+fi
+
+if [ -x "/sbin/${SHUTDOWN_CMD}" ] ; then
+	/sbin/${SHUTDOWN_CMD} ${SHUTDOWN_CMD_ARGS}
 	exit $?
-elif [ -x "/usr/sbin/shutdown" ] ; then
-	/usr/sbin/shutdown -r now
+elif [ -x "/usr/sbin/${SHUTDOWN_CMD}" ] ; then
+	/usr/sbin/${SHUTDOWN_CMD} ${SHUTDOWN_CMD_ARGS}
 	exit $?
 else
 	exit 1

--- a/tools/linux/ck-system-restart
+++ b/tools/linux/ck-system-restart
@@ -7,7 +7,7 @@ SHUTDOWN_CMD_ARGS='-r now'
 # Check based on init
 if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
 	SHUTDOWN_CMD=openrc-shutdown
-elif [ "$(ps -p 1 -o comm=)" = runit-init ]; then
+elif [ "$(ps -p 1 -o comm=)" = runit ]; then
 	SHUTDOWN_CMD=runit-init
 	SHUTDOWN_CMD_ARGS="6"
 fi

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -16,6 +16,7 @@ case "$(ps -p 1 -o comm=)" in
 		SHUTDOWN_CMD_ARGS='-p now'
 	;;
 	*)
+		# sysvinit compatible
 		SHUTDOWN_CMD=shutdown
 		SHUTDOWN_CMD_ARGS='-h now'
 	;;

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -7,8 +7,7 @@ SHUTDOWN_CMD_ARGS='-h now'
 # Check based on init
 if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
 	SHUTDOWN_CMD=openrc-shutdown
-fi
-if [ "$(ps -p 1 -o comm=)" = runit-init ]; then
+elif [ "$(ps -p 1 -o comm=)" = runit-init ]; then
 	SHUTDOWN_CMD=runit-init
 	SHUTDOWN_CMD_ARGS="0"
 fi

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -7,6 +7,7 @@ SHUTDOWN_CMD_ARGS='-h now'
 # Check based on init
 if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
 	SHUTDOWN_CMD=openrc-shutdown
+	SHUTDOWN_CMD_ARGS='-p now'
 elif [ "$(ps -p 1 -o comm=)" = runit ]; then
 	SHUTDOWN_CMD=runit-init
 	SHUTDOWN_CMD_ARGS="0"

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -1,11 +1,23 @@
 #!/bin/sh
+# ck-system-stop
 
-#Try for common tools
-if [ -x "/sbin/shutdown" ] ; then
-	/sbin/shutdown -h now
+SHUTDOWN_CMD=shutdown
+SHUTDOWN_CMD_ARGS='-h now'
+
+# Check based on init
+if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
+	SHUTDOWN_CMD=openrc-shutdown
+fi
+if [ "$(ps -p 1 -o comm=)" = runit-init ]; then
+	SHUTDOWN_CMD=runit-init
+	SHUTDOWN_CMD_ARGS="0"
+fi
+
+if [ -x "/sbin/${SHUTDOWN_CMD}" ] ; then
+	/sbin/${SHUTDOWN_CMD} ${SHUTDOWN_CMD_ARGS}
 	exit $?
-elif [ -x "/usr/sbin/shutdown" ] ; then
-	/usr/sbin/shutdown -h now
+elif [ -x "/usr/sbin/${SHUTDOWN_CMD}" ] ; then
+	/usr/sbin/${SHUTDOWN_CMD} ${SHUTDOWN_CMD_ARGS}
 	exit $?
 else
 	exit 1

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -7,7 +7,7 @@ SHUTDOWN_CMD_ARGS='-h now'
 # Check based on init
 if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
 	SHUTDOWN_CMD=openrc-shutdown
-elif [ "$(ps -p 1 -o comm=)" = runit-init ]; then
+elif [ "$(ps -p 1 -o comm=)" = runit ]; then
 	SHUTDOWN_CMD=runit-init
 	SHUTDOWN_CMD_ARGS="0"
 fi

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -5,13 +5,24 @@ SHUTDOWN_CMD=shutdown
 SHUTDOWN_CMD_ARGS='-h now'
 
 # Check based on init
-if [ "$(ps -p 1 -o comm=)" = openrc-init ]; then
-	SHUTDOWN_CMD=openrc-shutdown
-	SHUTDOWN_CMD_ARGS='-p now'
-elif [ "$(ps -p 1 -o comm=)" = runit ]; then
-	SHUTDOWN_CMD=runit-init
-	SHUTDOWN_CMD_ARGS="0"
-fi
+case "$(ps -p 1 -o comm=)" in
+	openrc-init)
+		SHUTDOWN_CMD=openrc-shutdown
+		SHUTDOWN_CMD_ARGS='-h now'
+	;;
+	runit)
+		SHUTDOWN_CMD=runit-init
+		SHUTDOWN_CMD_ARGS="0"
+	;;
+	s6-svscan)
+		SHUTDOWN_CMD=openrc-shutdown
+		SHUTDOWN_CMD_ARGS='-p now'
+	;;
+	*)
+		SHUTDOWN_CMD=shutdown
+		SHUTDOWN_CMD_ARGS='-h now'
+	;;
+esac
 
 if [ -x "/sbin/${SHUTDOWN_CMD}" ] ; then
 	/sbin/${SHUTDOWN_CMD} ${SHUTDOWN_CMD_ARGS}

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -1,9 +1,6 @@
 #!/bin/sh
 # ck-system-stop
 
-SHUTDOWN_CMD=shutdown
-SHUTDOWN_CMD_ARGS='-h now'
-
 # Check based on init
 case "$(ps -p 1 -o comm=)" in
 	openrc-init)
@@ -15,7 +12,7 @@ case "$(ps -p 1 -o comm=)" in
 		SHUTDOWN_CMD_ARGS="0"
 	;;
 	s6-svscan)
-		SHUTDOWN_CMD=openrc-shutdown
+		SHUTDOWN_CMD=shutdown
 		SHUTDOWN_CMD_ARGS='-p now'
 	;;
 	*)

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -11,14 +11,10 @@ case "$(ps -p 1 -o comm=)" in
 		SHUTDOWN_CMD=runit-init
 		SHUTDOWN_CMD_ARGS="0"
 	;;
-	s6-svscan)
-		SHUTDOWN_CMD=shutdown
-		SHUTDOWN_CMD_ARGS='-p now'
-	;;
 	*)
 		# sysvinit compatible
 		SHUTDOWN_CMD=shutdown
-		SHUTDOWN_CMD_ARGS='-h now'
+		SHUTDOWN_CMD_ARGS='-h -P now'
 	;;
 esac
 


### PR DESCRIPTION
Checks for openrc and runit via `init=/sbin/openrc-init` and `init=/sbin/runit-init` respectively.

Links:
* https://wiki.gentoo.org/wiki/Runit#Runit_as_the_init_system
* https://wiki.gentoo.org/wiki/OpenRC/openrc-init

Tested on Slackware Linux with `init=/sbin/openrc-init`