### PR TITLE
Fixes for Wayland on FreeBSD

### DIFF
--- a/src/ck-device-udev.c
+++ b/src/ck-device-udev.c
@@ -391,13 +391,16 @@ ck_device_new (guint    major,
         /* Start with other device as a default, we have special things
          * we do with DRM and EVDEV devices so find and tag them */
         device->category = DEVICE_OTHER;
-        if (g_strcmp0 (subsystem, "drm") == 0)
+        if ((g_strcmp0 (subsystem, "drm") == 0 && g_str_has_prefix (sysname, "card"))
+#ifndef __linux__
+                        /* on BSD, the dri/card0 -> drm/0 symlink gets resolved,
+                         * and subsystem is not emulated by libudev-devd */
+                        || strstr (device->devnode, "drm") != NULL
+#endif
+           )
         {
-                if (g_str_has_prefix (sysname, "card"))
-                {
-                        g_debug ("DEVICE_DRM");
-                        device->category = DEVICE_DRM;
-                }
+                g_debug ("DEVICE_DRM");
+                device->category = DEVICE_DRM;
         }
         else if (g_strcmp0 (subsystem, "input") == 0)
         {

--- a/src/ck-seat.c
+++ b/src/ck-seat.c
@@ -316,7 +316,7 @@ ck_seat_activate_session (CkSeat                *seat,
 
         g_debug ("Attempting to activate VT %u", num);
 
-        if (seat->priv->active_session != session) {
+        if (seat->priv->active_session != session && seat->priv->active_session != NULL) {
                 /* let the old session know it's about to change */
                 ck_session_set_active (seat->priv->active_session, FALSE, TRUE);
         }

--- a/src/ck-session.c
+++ b/src/ck-session.c
@@ -1701,6 +1701,15 @@ ck_session_get_device (CkSession *session,
         for (iter = session->priv->devices; iter != NULL; iter = g_list_next (iter)) {
                 if (ck_device_compare (iter->data, major, minor)) {
                         g_debug ("found device");
+                        CkDevice *device = CK_DEVICE (iter->data);
+                        if (ck_device_get_category(device) == DEVICE_EVDEV) {
+                                struct stat st;
+                                if (fstat(ck_device_get_fd(device), &st) == -1 && errno == EBADF) {
+                                        g_debug ("but it was a dead input device, removing");
+                                        session->priv->devices = g_list_remove (session->priv->devices, device);
+                                        return NULL;
+                                }
+                        }
                         return iter->data;
                 }
         }


### PR DESCRIPTION
- `/dev/dri/card0` is a symlink to `../drm/0` on FreeBSD. When CK2 tries to determine the device type, the path gets resolved, and so it's not `card0`. Also the subsystem is not set by [libudev-devd](https://github.com/FreeBSDDesktop/libudev-devd).
- when unplugging an input device and plugging it back in, CK2 would refuse to attach an already attached device. Actually, my compositor tried to detach it, but the file descriptor was already dead. (I guess on Linux the `/dev/*` device doesn't die until udev consumers have detached it, because `/dev` is controlled by udev — in our case, it's controlled by `devfs` in the kernel) Let's check if the device died on re-attaching.
- termios raw mode should be set on the tty, otherwise FreeBSD vt wouldn't ignore keyboard input, which can cause really weird things to happen (my Weston would quit when pressing Enter, lol)