### PR TITLE
change the inhibitor lock handling to use the named_pipe_path as a re…

### DIFF
--- a/src/ck-inhibit-manager.c
+++ b/src/ck-inhibit-manager.c
@@ -152,7 +152,7 @@ cb_changed_event (CkInhibit *inhibit,
 
                 /* When an inhibitor loses it lockes, remove the inhibitor from
                  * the list */
-                ck_inhibit_manager_remove_lock (manager, ck_inhibit_get_who (inhibit));
+                ck_inhibit_manager_remove_lock (manager, ck_inhibit_get_named_pipe_path (inhibit));
         }
 }
 
@@ -235,8 +235,7 @@ ck_inhibit_manager_create_lock (CkInhibitManager *manager,
 /**
  * ck_inhibit_manager_remove_lock:
  * @manager: The @CkInhibitManager object
- * @who:  A human-readable, descriptive string of who has taken
- *        the lock. Example: "Xfburn"
+ * @named_pipe_path:  The unique named pipe path to lock on.
  *
  * Finds the inhibit lock @who and removes it.
  *
@@ -244,7 +243,7 @@ ck_inhibit_manager_create_lock (CkInhibitManager *manager,
  **/
 gboolean
 ck_inhibit_manager_remove_lock (CkInhibitManager *manager,
-                                const gchar      *who)
+                                const gchar      *named_pipe_path)
 {
         CkInhibitManagerPrivate *priv;
         GList                   *l;
@@ -256,7 +255,7 @@ ck_inhibit_manager_remove_lock (CkInhibitManager *manager,
         priv = CK_INHIBIT_MANAGER_GET_PRIVATE (manager);
 
         for (l = g_list_first (priv->inhibit_list); l != NULL; l = l->next) {
-                if (l->data && g_strcmp0 (ck_inhibit_get_who (l->data), who) == 0) {
+                if (l->data && g_strcmp0 (ck_inhibit_get_named_pipe_path (l->data), named_pipe_path) == 0) {
                         CkInhibit *inhibit = l->data;
 
                         /* Found it! Remove it from the list and unref the object */

--- a/src/ck-inhibit-manager.h
+++ b/src/ck-inhibit-manager.h
@@ -63,7 +63,7 @@ gint              ck_inhibit_manager_create_lock                 (CkInhibitManag
                                                                   pid_t             pid);
 
 gboolean          ck_inhibit_manager_remove_lock                 (CkInhibitManager *manager,
-                                                                  const gchar      *who);
+                                                                  const gchar      *named_pipe_path);
 
 gboolean          ck_inhibit_manager_is_shutdown_delayed         (CkInhibitManager *manager);
 gboolean          ck_inhibit_manager_is_suspend_delayed          (CkInhibitManager *manager);

--- a/src/ck-inhibit.c
+++ b/src/ck-inhibit.c
@@ -750,6 +750,21 @@ ck_inhibit_get_mode (CkInhibit   *inhibit)
 }
 
 /**
+ * ck_inhibit_get_named_pipe:
+ * @inhibit: The @CkInhibit object
+ *
+ * Return value: the inhibit mode, either "delay" or "block" (or NULL on failure).
+ **/
+const gchar*
+ck_inhibit_get_named_pipe_path (CkInhibit   *inhibit)
+{
+        g_return_val_if_fail (CK_IS_INHIBIT (inhibit), NULL);
+
+        return inhibit->priv->named_pipe_path;
+}
+
+
+/**
  * ck_inhibit_get_uid:
  * @inhibit: The @CkInhibit object
  *

--- a/src/ck-inhibit.h
+++ b/src/ck-inhibit.h
@@ -101,6 +101,7 @@ const gchar    *ck_inhibit_get_what                    (CkInhibit   *inhibit);
 const gchar    *ck_inhibit_get_who                     (CkInhibit   *inhibit);
 const gchar    *ck_inhibit_get_why                     (CkInhibit   *inhibit);
 const gchar    *ck_inhibit_get_mode                    (CkInhibit   *inhibit);
+const gchar    *ck_inhibit_get_named_pipe_path         (CkInhibit   *inhibit);
 CkInhibitMode   ck_inhibit_get_inhibit_mode            (CkInhibit   *inhibit);
 uid_t           ck_inhibit_get_uid                     (CkInhibit   *inhibit);
 pid_t           ck_inhibit_get_pid                     (CkInhibit   *inhibit);


### PR DESCRIPTION
…ference

since one process can take multiple inhibitor locks make sure that the correct
entry gets removed from the inhibit_list by using 'named_pipe_path' to find
the proper entry instead of 'who' because that is not unique