### PR TITLE
NetBSD: merge fixes from pkgsrc

### DIFF
--- a/src/ck-sysdeps-netbsd.c
+++ b/src/ck-sysdeps-netbsd.c
@@ -493,7 +493,7 @@ ck_make_tmpfs (guint uid, guint gid, const gchar *dest)
 
         opts = g_strdup_printf ("mode=0700,uid=%d", uid);
 
-        result = mount("tmpfs", dest, 0, opts);
+        result = mount("tmpfs", dest, 0, opts, strlen(opts));
 
         g_free (opts);
 

--- a/src/ck-sysdeps-netbsd.c
+++ b/src/ck-sysdeps-netbsd.c
@@ -36,7 +36,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/sysctl.h>
-#include <sys/user.h>
 #include <sys/ioctl.h>
 
 #ifdef HAVE_SYS_MOUNT_H


### PR DESCRIPTION
This makes ConsoleKit work again on recent NetBSD versions.

- There's no `sys/user.h` header on NetBSD since 2017 so don't try to include it. It was an empty header and only caused a deprecation compiler warning since 2011.
- The `mount` system call needs a fourth argument for the length of the data since NetBSD 5.0 (released in 2009, versions that predate the change being unsupported since... 2012?).