### PR TITLE
Remove pm-utils dependency and replace it with swsusp kernel methods

### DIFF
--- a/tools/linux/ck-system-hibernate
+++ b/tools/linux/ck-system-hibernate
@@ -1,12 +1,3 @@
 #!/bin/sh
 
-#Try for common tools
-if [ -x "/sbin/pm-hibernate" ] ; then
-	/sbin/pm-hibernate
-	exit $?
-elif [ -x "/usr/sbin/pm-hibernate" ] ; then
-	/usr/sbin/pm-hibernate
-	exit $?
-else
-	exit 1
-fi
+echo disk > /sys/power/state

--- a/tools/linux/ck-system-hybridsleep
+++ b/tools/linux/ck-system-hybridsleep
@@ -1,12 +1,4 @@
 #!/bin/sh
 
-#Try for common tools
-if [ -x "/sbin/pm-suspend-hybrid" ] ; then
-	/sbin/pm-suspend-hybrid
-	exit $?
-elif [ -x "/usr/sbin/pm-suspend-hybrid" ] ; then
-	/usr/sbin/pm-suspend-hybrid
-	exit $?
-else
-	exit 1
-fi
+echo suspend > /sys/power/disk
+echo disk > /sys/power/state

--- a/tools/linux/ck-system-restart
+++ b/tools/linux/ck-system-restart
@@ -1,12 +1,3 @@
 #!/bin/sh
 
-#Try for common tools
-if [ -x "/sbin/shutdown" ] ; then
-	/sbin/shutdown -r now
-	exit $?
-elif [ -x "/usr/sbin/shutdown" ] ; then
-	/usr/sbin/shutdown -r now
-	exit $?
-else
-	exit 1
-fi
+shutdown -r now

--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -1,12 +1,3 @@
 #!/bin/sh
 
-#Try for common tools
-if [ -x "/sbin/shutdown" ] ; then
-	/sbin/shutdown -h now
-	exit $?
-elif [ -x "/usr/sbin/shutdown" ] ; then
-	/usr/sbin/shutdown -h now
-	exit $?
-else
-	exit 1
-fi
+shutdown -h now

--- a/tools/linux/ck-system-suspend
+++ b/tools/linux/ck-system-suspend
@@ -1,12 +1,3 @@
 #!/bin/sh
 
-#Try for common tools
-if [ -x "/sbin/pm-suspend" ] ; then
-	/sbin/pm-suspend
-	exit $?
-elif [ -x "/usr/sbin/pm-suspend" ] ; then
-	/usr/sbin/pm-suspend
-	exit $?
-else
-	exit 1
-fi
+echo mem > /sys/power/state


### PR DESCRIPTION
Fixes #114 and #110.

This  is a small patch to finally remove pm-utils as a dependency from consolekit. It uses a kernel feature that any kernel released in the past 20 years supports and has been the default for 10 years. The dbus interface is unchanged and DEs that support consolekit can still call it through the same GUI methods as before.

I also changed the shutdown and reboot after seeing #113. As far as I know, `poweroff` and `reboot` exist in all linux configurations under `/usr/bin` and are "init agnostic", but I haven't tested it. Maybe `init 0` and `init 6` are more universal, I'd like to hear someone else's thoughts on that change.