### PR TITLE
[openbsd] give time for suspend and hibernate to settle

### DIFF
--- a/tools/openbsd/ck-system-hibernate
+++ b/tools/openbsd/ck-system-hibernate
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-/usr/sbin/ZZZ
+# add small time buffer for a screen lock to settle first (when called by a DE)
+(sleep 2; /usr/sbin/ZZZ) &

--- a/tools/openbsd/ck-system-suspend
+++ b/tools/openbsd/ck-system-suspend
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-/usr/sbin/zzz
+# add small time buffer for a screen lock to settle first (when called by a DE)
+(sleep 2; /usr/sbin/zzz) &


### PR DESCRIPTION
When suspending from a Desktop Environment, the screen lock might not have time to fire up meaning that on resume there will be a second or so where the content of the unlocked display can be seen (it cannot be interacted with but still). Add an arbitrary 2 seconds backgrounded buffer so that the lock has time to activate.