### PR TITLE
Manager.ListSessions support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ AC_CHECK_HEADERS([unistd.h paths.h sys/vt.h sys/consio.h fcntl.h limits.h \
                   sys/wait.h sys/resource.h sys/mount.h sys/param.h ftw.h \
 		  sys/sysmacros.h sys/types.h libudev.h linux/input.h \
 		  sys/mkdev.h devattr.h sys/kd.h sys/kbio.h libprop/proplib.h \
-		  linux/kd.h sys/queue.h sys/stat.h sys/fcntl.h \
+		  linux/kd.h sys/queue.h sys/stat.h sys/fcntl.h sys/event.h \
 		  dev/wscons/wsdisplay_usl_io.h dev/wscons/wsconsio.h \
 		  vfs/tmpfs/tmpfs_mount.h])
 

--- a/libconsolekit/libconsolekit.c
+++ b/libconsolekit/libconsolekit.c
@@ -40,13 +40,6 @@
 
 #include "libconsolekit.h"
 
-#define CK_NAME          "org.freedesktop.ConsoleKit"
-#define CK_MANAGER_PATH  "/org/freedesktop/ConsoleKit/Manager"
-#define CK_MANAGER_NAME  CK_NAME ".Manager"
-#define CK_SEAT_NAME     CK_NAME ".Seat"
-#define CK_SESSION_NAME  CK_NAME ".Session"
-
-
 #define CONSOLEKIT_ERROR lib_consolekit_error_quark ()
 
 /**

--- a/libconsolekit/libconsolekit.h
+++ b/libconsolekit/libconsolekit.h
@@ -32,6 +32,12 @@
 
 #include <glib-object.h>
 
+#define CK_NAME          "org.freedesktop.ConsoleKit"
+#define CK_MANAGER_PATH  "/org/freedesktop/ConsoleKit/Manager"
+#define CK_MANAGER_NAME  CK_NAME ".Manager"
+#define CK_SEAT_NAME     CK_NAME ".Seat"
+#define CK_SESSION_NAME  CK_NAME ".Session"
+
 #define LIB_TYPE_CONSOLEKIT           (lib_consolekit_get_type ())
 #define LIB_CONSOLEKIT(o)             (G_TYPE_CHECK_INSTANCE_CAST ((o), LIB_TYPE_CONSOLEKIT, LibConsoleKit))
 #define LIB_CONSOLEKIT_CLASS(k)       (G_TYPE_CHECK_CLASS_CAST((k), LIB_TYPE_CONSOLEKIT, LibConsoleKitClass))

--- a/libconsolekit/sd-compat.c
+++ b/libconsolekit/sd-compat.c
@@ -1,6 +1,42 @@
+/*
+ * Copyright (c) 2023, Serenity Cybersecurity, LLC <license@futurecrew.ru>
+ *                     Author: Gleb Popov <arrowd@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "config.h"
 
 #include <sys/types.h>
+#ifdef HAVE_POLL_H
+#include <poll.h>
+#endif
+
+#ifdef HAVE_SYS_EVENT_H
+#include <sys/event.h>
+#endif
 
 #include <glib.h>
 #include <glib-object.h>
@@ -9,6 +45,7 @@
 #include <gio/gio.h>
 
 #include "libconsolekit.h"
+#include "sd-login.h"
 
 int
 sd_session_get_class(const char *session, char **class)
@@ -303,3 +340,146 @@ sd_get_sessions(char ***sessions)
 
 	return ret;
 }
+
+#if defined(HAVE_SYS_EVENT_H) && defined(EVFILT_USER) && defined(HAVE_POLL_H)
+static
+void on_signal(GDBusProxy *manager,
+				gchar *sender_name,
+				gchar *signal_name,
+				GVariant *parameters,
+				sd_login_monitor *monitor)
+{
+	struct kevent e;
+	if (strcmp(signal_name, "SessionNew") && strcmp(signal_name, "SessionRemoved"))
+		return;
+	EV_SET(&e, 0, EVFILT_USER, 0, NOTE_TRIGGER, 0, NULL);
+	kevent(monitor->kq, &e, 1, 0, 0, 0);
+}
+
+int sd_login_monitor_new(const char *category, sd_login_monitor **ret)
+{
+	struct kevent e;
+	GError **error = NULL;
+	sd_login_monitor *monitor = NULL;
+
+	monitor = malloc(sizeof(sd_login_monitor));
+	if (!monitor)
+		return -ENOMEM;
+
+	monitor->kq = kqueue();
+	monitor->manager = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
+													G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
+													NULL,
+													CK_NAME,
+													CK_MANAGER_PATH,
+													CK_MANAGER_NAME,
+													NULL,
+													error);
+
+	if (monitor->kq == -1 || monitor->manager == NULL)
+	{
+		sd_login_monitor_unref (monitor);
+		return -ENXIO;
+	}
+
+	// XXX can't connect to these signals without pulling in ck-manager-generated.h
+	// if (!strcmp (category, "session") || category == NULL)
+	// {
+	// 	g_signal_connect (monitor->manager, "session-new", G_CALLBACK (on_session_changed), monitor);
+	// 	g_signal_connect (monitor->manager, "session-removed", G_CALLBACK (on_session_changed), monitor);
+	// }
+
+	monitor->category = category;
+	g_signal_connect (monitor->manager, "g-signal", G_CALLBACK (on_signal), monitor);
+
+	EV_SET(&e, 0, EVFILT_USER, EV_ADD | EV_CLEAR, 0, 0, NULL);
+	kevent(monitor->kq, &e, 1, 0, 0, 0);
+
+	*ret = monitor;
+	return 0;
+}
+
+sd_login_monitor *sd_login_monitor_unref(sd_login_monitor *monitor)
+{
+	if (!monitor)
+		return NULL;
+
+	if (monitor->kq != -1)
+		close (monitor->kq);
+	if (monitor->manager)
+	{
+		g_signal_handlers_disconnect_by_func (monitor->manager, on_signal, monitor);
+		g_clear_object (&monitor->manager);
+	}
+	free (monitor);
+	return NULL;
+}
+
+void sd_login_monitor_unrefp(sd_login_monitor **m)
+{
+	sd_login_monitor_unref(*m);
+}
+
+int sd_login_monitor_flush(sd_login_monitor *monitor)
+{
+	struct kevent e;
+	EV_SET(&e, 0, EVFILT_USER, EV_CLEAR, 0, 0, NULL);
+	if (kevent(monitor->kq, &e, 1, 0, 0, 0) == -1)
+		return -(errno);
+	return 0;
+}
+
+int sd_login_monitor_get_fd(sd_login_monitor *monitor)
+{
+	if (monitor->kq == -1)
+		return -EBADF;
+	return monitor->kq;
+}
+
+int sd_login_monitor_get_events(sd_login_monitor *monitor)
+{
+	return POLLIN;
+}
+
+int sd_login_monitor_get_timeout(sd_login_monitor *monitor, uint64_t *timeout_usec)
+{
+	return -1;
+}
+
+#else
+
+int sd_login_monitor_new(const char *category, sd_login_monitor **ret)
+{
+	return -ENOTSUP;
+}
+
+sd_login_monitor *sd_login_monitor_unref(sd_login_monitor *monitor)
+{
+	return NULL;
+}
+
+void sd_login_monitor_unrefp(sd_login_monitor **m)
+{
+}
+
+int sd_login_monitor_flush(sd_login_monitor *monitor)
+{
+	return -ENOTSUP;
+}
+
+int sd_login_monitor_get_fd(sd_login_monitor *monitor)
+{
+	return -ENOTSUP;
+}
+
+int sd_login_monitor_get_events(sd_login_monitor *monitor)
+{
+	return 0;
+}
+
+int sd_login_monitor_get_timeout(sd_login_monitor *monitor, uint64_t *timeout_usec)
+{
+	return -1;
+}
+
+#endif

--- a/libconsolekit/sd-login.h
+++ b/libconsolekit/sd-login.h
@@ -1,4 +1,21 @@
+#pragma once
+
 #include <sys/types.h>
+
+typedef struct
+{
+    int kq;
+    GDBusProxy *manager;
+    const char *category;
+} sd_login_monitor;
+
+int sd_login_monitor_new(const char *category, sd_login_monitor **ret);
+sd_login_monitor *sd_login_monitor_unref(sd_login_monitor *monitor);
+void sd_login_monitor_unrefp(sd_login_monitor **monitor);
+int sd_login_monitor_flush(sd_login_monitor *monitor);
+int sd_login_monitor_get_fd(sd_login_monitor *monitor);
+int sd_login_monitor_get_events(sd_login_monitor *monitor);
+int sd_login_monitor_get_timeout(sd_login_monitor *monitor, uint64_t *timeout_usec);
 
 int sd_session_get_class(const char *session, char **class);
 int sd_session_get_seat(const char *session, char **seat);

--- a/libconsolekit/test-libconsolekit.c
+++ b/libconsolekit/test-libconsolekit.c
@@ -42,7 +42,7 @@
 #include <gio/gio.h>
 
 #include "libconsolekit.h"
-
+#include "sd-login.h"
 
 
 static void
@@ -320,6 +320,33 @@ test_session_get_vt (LibConsoleKit *ck,
 }
 
 static void
+test_sd_login_monitor (LibConsoleKit *ck)
+{
+    sd_login_monitor* m;
+    int res = sd_login_monitor_new ("session", &m);
+    if (res < 0) {
+        g_print ("sd_login_monitor : new error %s\n", strerror(-res));
+        return;
+    }
+
+    res = sd_login_monitor_get_fd (m);
+    if (res < 0) {
+        g_print ("sd_login_monitor : get_fd error %s\n", strerror(-res));
+        return;
+    }
+
+    res = sd_login_monitor_flush (m);
+    if (res < 0) {
+        g_print ("sd_login_monitor : flush error %s\n", strerror(-res));
+        return;
+    }
+
+    sd_login_monitor_unref (m);
+
+    g_print ("sd_login_monitor : OK\n");
+}
+
+static void
 test_pid_get_session (LibConsoleKit *ck,
                       gint pid)
 {
@@ -415,6 +442,8 @@ main (int   argc,
     test_session_get_tty (ck, opt_session);
 
     test_session_get_vt (ck, opt_session);
+
+    test_sd_login_monitor (ck);
 
     test_pid_get_session (ck, opt_pid);
 

--- a/src/org.freedesktop.ConsoleKit.Manager.xml
+++ b/src/org.freedesktop.ConsoleKit.Manager.xml
@@ -549,6 +549,21 @@
       </doc:doc>
     </method>
 
+    <method name="ListSessions">
+      <arg name="sessions" direction="out" type="a(susso)">
+        <doc:doc>
+          <doc:summary>an array of structures (session ID, user ID, user name, seat ID, session path)</doc:summary>
+        </doc:doc>
+      </arg>
+      <doc:doc>
+        <doc:description>
+          <doc:para>Retrieves a list of all <doc:ref type="interface" to="Session">Sessions</doc:ref>
+          that are present on the system.</doc:para>
+        </doc:description>
+        <doc:seealso><doc:ref type="method" to="Manager.GetSeats">GetSeats()</doc:ref></doc:seealso>
+      </doc:doc>
+    </method>
+
     <method name="GetSeats">
       <arg name="seats" direction="out" type="ao">
         <doc:doc>


### PR DESCRIPTION
Another piece of login1 compatibility required by SDDM.

There seem to be a deep misconception inside ConsoleKit - it confuses objects paths with ids all over the place. I believe we should stop plugging `g_path_get_basename` everywhere but rather just treat IDs like login1 does. This PR doesn't fix it, though.

Based on #141 