### PR TITLE
Follow logind in seat/session naming scheme.

### DIFF
--- a/src/ck-manager.c
+++ b/src/ck-manager.c
@@ -62,11 +62,6 @@
 
 #define CK_SEAT_DIR            SYSCONFDIR "/ConsoleKit/seats.d"
 #define LOG_FILE               LOCALSTATEDIR "/log/ConsoleKit/history"
-#define DBUS_NAME              "org.freedesktop.ConsoleKit"
-#define CK_DBUS_PATH           "/org/freedesktop/ConsoleKit"
-#define CK_MANAGER_DBUS_PATH   CK_DBUS_PATH "/Manager"
-#define DBUS_SESSION_INTERFACE DBUS_NAME ".Session"
-#define DBUS_MANAGER_INTERFACE DBUS_NAME ".Manager"
 
 typedef enum {
         PREPARE_FOR_SHUTDOWN,
@@ -593,7 +588,7 @@ generate_session_id (CkManager *manager)
  again:
         serial = get_next_session_serial (manager);
         g_free (id);
-        id = g_strdup_printf ("%s/Session%u", CK_DBUS_PATH, serial);
+        id = g_strdup_printf ("Session%u", serial);
 
         if (g_hash_table_lookup (manager->priv->sessions, id)) {
                 goto again;
@@ -744,7 +739,7 @@ log_seat_session_added_event (CkManager  *manager,
         ck_seat_get_id (seat, &sid, NULL);
 
         event.event.seat_session_added.seat_id = (char *)get_object_id_basename (sid);
-        event.event.seat_session_added.session_id = (char *)get_object_id_basename (ssid);
+        event.event.seat_session_added.session_id = (char *) ssid;
 
         session = g_hash_table_lookup (manager->priv->sessions, ssid);
         if (session != NULL) {
@@ -799,7 +794,7 @@ log_seat_session_removed_event (CkManager  *manager,
         ck_seat_get_id (seat, &sid, NULL);
 
         event.event.seat_session_removed.seat_id = (char *)get_object_id_basename (sid);
-        event.event.seat_session_removed.session_id = (char *)get_object_id_basename (ssid);
+        event.event.seat_session_removed.session_id = (char *) ssid;
 
         session = g_hash_table_lookup (manager->priv->sessions, ssid);
         if (session != NULL) {
@@ -852,7 +847,7 @@ log_seat_active_session_changed_event (CkManager  *manager,
         ck_seat_get_id (seat, &sid, NULL);
 
         event.event.seat_active_session_changed.seat_id = (char *)get_object_id_basename (sid);
-        event.event.seat_active_session_changed.session_id = (char *)get_object_id_basename (ssid);
+        event.event.seat_active_session_changed.session_id = (char *) ssid;
 
         error = NULL;
         res = ck_event_logger_queue_event (manager->priv->logger, &event, &error);
@@ -2848,7 +2843,7 @@ open_session_for_leader (CkManager             *manager,
                           manager);
 
         /* let consumers know of the new session */
-        console_kit_manager_emit_session_new (CONSOLE_KIT_MANAGER (manager), ssid, ssid);
+        console_kit_manager_emit_session_new (CONSOLE_KIT_MANAGER (manager), ssid, ck_session_get_path (session));
 
         g_object_unref (session);
         g_free (runtime_dir);
@@ -3098,7 +3093,7 @@ dbus_get_session_for_cookie (ConsoleKitManager     *ckmanager,
 
         g_debug ("CkManager: Found session '%s'", ssid);
 
-        console_kit_manager_complete_get_session_for_cookie (ckmanager, context, ssid);
+        console_kit_manager_complete_get_session_for_cookie (ckmanager, context, ck_session_get_path (session));
 
         g_free (ssid);
 
@@ -3327,7 +3322,7 @@ remove_session_for_cookie (CkManager  *manager,
         /* let consumers know the session is gone */
         console_kit_manager_emit_session_removed (CONSOLE_KIT_MANAGER (manager),
                                                   orig_ssid,
-                                                  orig_ssid);
+                                                  ck_session_get_path (orig_session));
 
         if (get_runtime_dir_for_user (manager, unix_user) == NULL) {
                 /* We removed the session and now there's no runtime dir
@@ -3632,7 +3627,7 @@ collect_sessions_for_user (char            *ssid,
         uid = console_kit_session_get_unix_user (CONSOLE_KIT_SESSION(session));
 
         if (uid == data->uid) {
-                g_hash_table_add (data->hash, g_strdup (ssid));
+                g_hash_table_add (data->hash, g_strdup (ck_session_get_path (session)));
         }
 }
 
@@ -3869,23 +3864,20 @@ dbus_list_sessions (ConsoleKitManager     *ckmanager,
 
         g_hash_table_iter_init (&session_iter, manager->priv->sessions);
         while (g_hash_table_iter_next (&session_iter,  (gpointer *)&key,  (gpointer *)&value)) {
-                gchar *sid0, *sid;
-                gchar *ssid = g_path_get_basename (key);
+                gchar *sid;
                 struct passwd *ent = getpwuid (console_kit_session_get_unix_user ( CONSOLE_KIT_SESSION(value) ));
-                ck_session_get_seat_id ( CK_SESSION(value), &sid0, NULL );
-                sid = g_path_get_basename (sid0);
+                ck_session_get_seat_id ( CK_SESSION(value), &sid, NULL );
 
                 session = g_variant_new("(susso)",
-                                        ssid,
+                                        key,
                                         console_kit_session_get_unix_user ( CONSOLE_KIT_SESSION(value) ),
                                         ent ? ent->pw_name : "",
                                         sid,
-                                        key
+                                        ck_session_get_path ( CK_SESSION(value) )
                                         );
 
                 g_variant_builder_add_value (&session_builder, session);
 
-                g_free (sid0);
                 g_free (sid);
         }
 
@@ -3962,7 +3954,7 @@ dbus_get_sessions (ConsoleKitManager     *ckmanager,
                    GDBusMethodInvocation *context)
 {
         CkManager    *manager;
-        const gchar **sessions;
+        GPtrArray    *sessions;
 
         TRACE ();
 
@@ -3970,16 +3962,23 @@ dbus_get_sessions (ConsoleKitManager     *ckmanager,
 
         g_return_val_if_fail (CK_IS_MANAGER (manager), FALSE);
 
-        sessions = (const gchar**)g_hash_table_get_keys_as_array (manager->priv->sessions, NULL);
+        sessions = g_hash_table_get_values_as_ptr_array (manager->priv->sessions);
 
         /* gdbus/gvariant requires that we throw an error to return NULL */
-        if (sessions == NULL) {
+        if (sessions->len == 0) {
                 throw_error (context, CK_MANAGER_ERROR_NO_SESSIONS, _("There are no sessions"));
                 return TRUE;
         }
 
-        console_kit_manager_complete_get_sessions (ckmanager, context, sessions);
-        g_free (sessions);
+        /* replace each session with its path */
+        for (guint i = 0; i < sessions->len; i++) {
+                sessions->pdata[i] = (gpointer)ck_session_get_path ( CK_SESSION(sessions->pdata[i]) );
+        }
+
+        g_ptr_array_add (sessions, NULL);
+        console_kit_manager_complete_get_sessions (ckmanager, context, (const gchar**)sessions->pdata);
+        g_ptr_array_unref (sessions);
+
         return TRUE;
 }
 

--- a/src/ck-manager.c
+++ b/src/ck-manager.c
@@ -607,7 +607,7 @@ generate_seat_id (CkManager *manager)
  again:
         serial = get_next_seat_serial (manager);
         g_free (id);
-        id = g_strdup_printf ("%s/seat%u", CK_DBUS_PATH, serial);
+        id = g_strdup_printf ("seat%u", serial);
 
         if (g_hash_table_lookup (manager->priv->seats, id)) {
                 goto again;
@@ -649,7 +649,7 @@ log_seat_added_event (CkManager  *manager,
         ck_seat_get_id (seat, &sid, NULL);
         ck_seat_get_kind (seat, &seat_kind, NULL);
 
-        event.event.seat_added.seat_id = (char *)get_object_id_basename (sid);
+        event.event.seat_added.seat_id = sid;
         event.event.seat_added.seat_kind = (int)seat_kind;
 
         error = NULL;
@@ -681,7 +681,7 @@ log_seat_removed_event (CkManager  *manager,
         ck_seat_get_id (seat, &sid, NULL);
         ck_seat_get_kind (seat, &seat_kind, NULL);
 
-        event.event.seat_removed.seat_id = (char *)get_object_id_basename (sid);
+        event.event.seat_removed.seat_id = sid;
         event.event.seat_removed.seat_kind = (int)seat_kind;
 
         error = NULL;
@@ -738,7 +738,7 @@ log_seat_session_added_event (CkManager  *manager,
         sid = NULL;
         ck_seat_get_id (seat, &sid, NULL);
 
-        event.event.seat_session_added.seat_id = (char *)get_object_id_basename (sid);
+        event.event.seat_session_added.seat_id = sid;
         event.event.seat_session_added.session_id = (char *) ssid;
 
         session = g_hash_table_lookup (manager->priv->sessions, ssid);
@@ -793,7 +793,7 @@ log_seat_session_removed_event (CkManager  *manager,
         sid = NULL;
         ck_seat_get_id (seat, &sid, NULL);
 
-        event.event.seat_session_removed.seat_id = (char *)get_object_id_basename (sid);
+        event.event.seat_session_removed.seat_id = sid;
         event.event.seat_session_removed.session_id = (char *) ssid;
 
         session = g_hash_table_lookup (manager->priv->sessions, ssid);
@@ -846,7 +846,7 @@ log_seat_active_session_changed_event (CkManager  *manager,
         sid = NULL;
         ck_seat_get_id (seat, &sid, NULL);
 
-        event.event.seat_active_session_changed.seat_id = (char *)get_object_id_basename (sid);
+        event.event.seat_active_session_changed.seat_id = sid;
         event.event.seat_active_session_changed.session_id = (char *) ssid;
 
         error = NULL;
@@ -884,7 +884,7 @@ log_seat_device_added_event (CkManager   *manager,
 
         g_variant_get (device, "(ss)", &device_type, &device_id);
 
-        event.event.seat_device_added.seat_id = (char *)get_object_id_basename (sid);
+        event.event.seat_device_added.seat_id = sid;
 
         event.event.seat_device_added.device_id = device_id;
         event.event.seat_device_added.device_type = device_type;
@@ -926,7 +926,7 @@ log_seat_device_removed_event (CkManager   *manager,
 
         g_variant_get (device, "(ss)", &device_type, &device_id);
 
-        event.event.seat_device_removed.seat_id = (char *)get_object_id_basename (sid);
+        event.event.seat_device_removed.seat_id = sid;
 
         event.event.seat_device_removed.device_id = device_id;
         event.event.seat_device_removed.device_type = device_type;
@@ -2551,8 +2551,8 @@ add_new_seat (CkManager *manager,
         ck_manager_dump (manager);
         ck_seat_run_programs (seat, NULL, NULL, "seat_added");
 
-        g_debug ("Emitting seat-added: %s", sid);
-        console_kit_manager_emit_seat_added (CONSOLE_KIT_MANAGER (manager), sid);
+        g_debug ("Emitting seat-added: %s", ck_seat_get_path (seat));
+        console_kit_manager_emit_seat_added (CONSOLE_KIT_MANAGER (manager), ck_seat_get_path (seat));
 
         log_seat_added_event (manager, seat);
 
@@ -2594,8 +2594,8 @@ remove_seat (CkManager *manager,
         ck_manager_dump (manager);
         ck_seat_run_programs (seat, NULL, NULL, "seat_removed");
 
-        g_debug ("Emitting seat-removed: %s", sid);
-        console_kit_manager_emit_seat_removed (CONSOLE_KIT_MANAGER (manager), sid);
+        g_debug ("Emitting seat-removed: %s", ck_seat_get_path (orig_seat));
+        console_kit_manager_emit_seat_removed (CONSOLE_KIT_MANAGER (manager), ck_seat_get_path (orig_seat));
 
         log_seat_removed_event (manager, orig_seat);
 
@@ -2663,10 +2663,7 @@ find_seat_for_session (CkManager *manager,
         }
 
         if ((is_static_x11 || is_static_text) && vtnr > 0) {
-                char *sid;
-                sid = g_strdup_printf ("%s/seat%u", CK_DBUS_PATH, 0);
-                seat = g_hash_table_lookup (manager->priv->seats, sid);
-                g_free (sid);
+                seat = g_hash_table_lookup (manager->priv->seats, "seat0");
         }
 
         return seat;
@@ -3914,7 +3911,7 @@ dbus_list_seats (ConsoleKitManager     *ckmanager,
         while (g_hash_table_iter_next (&seat_iter,  (gpointer *)&key,  (gpointer *)&value)) {
                 seat = g_variant_new("(so)",
                                      console_kit_seat_get_name( CONSOLE_KIT_SEAT(value) ),
-                                     key);
+                                     ck_seat_get_path (value));
 
                 g_variant_builder_add_value (&seat_builder, seat);
         }
@@ -3928,7 +3925,7 @@ dbus_get_seats (ConsoleKitManager     *ckmanager,
                 GDBusMethodInvocation *context)
 {
         CkManager    *manager;
-        const gchar **seats;
+        GPtrArray    *seats;
 
         TRACE ();
 
@@ -3936,16 +3933,22 @@ dbus_get_seats (ConsoleKitManager     *ckmanager,
 
         g_return_val_if_fail (CK_IS_MANAGER (manager), FALSE);
 
-        seats = (const gchar**)g_hash_table_get_keys_as_array (manager->priv->seats, NULL);
+        seats = g_hash_table_get_values_as_ptr_array (manager->priv->seats);
 
         /* gdbus/gvariant requires that we throw an error to return NULL */
-        if (seats == NULL) {
+        if (seats->len == 0) {
                 throw_error (context, CK_MANAGER_ERROR_NO_SEATS, _("User has no seats"));
                 return TRUE;
         }
 
-        console_kit_manager_complete_get_seats (ckmanager, context, seats);
-        g_free (seats);
+        /* replace each session with its path */
+        for (guint i = 0; i < seats->len; i++) {
+                seats->pdata[i] = (gpointer) ck_seat_get_path ( CK_SEAT(seats->pdata[i]) );
+        }
+
+        g_ptr_array_add (seats, NULL);
+        console_kit_manager_complete_get_seats (ckmanager, context, (const gchar**)seats->pdata);
+        g_ptr_array_unref (seats);
         return TRUE;
 }
 
@@ -4013,8 +4016,8 @@ add_seat_for_file (CkManager  *manager,
         ck_manager_dump (manager);
         ck_seat_run_programs (seat, NULL, NULL, "seat_added");
 
-        g_debug ("Emitting seat-added: %s", sid);
-        console_kit_manager_emit_seat_added (CONSOLE_KIT_MANAGER (manager), sid);
+        g_debug ("Emitting seat-added: %s", ck_seat_get_path (seat));
+        console_kit_manager_emit_seat_added (CONSOLE_KIT_MANAGER (manager), ck_seat_get_path (seat));
 
         log_seat_added_event (manager, seat);
 }

--- a/src/ck-manager.h
+++ b/src/ck-manager.h
@@ -27,6 +27,12 @@
 
 #include "ck-seat.h"
 
+#define DBUS_NAME              "org.freedesktop.ConsoleKit"
+#define CK_DBUS_PATH           "/org/freedesktop/ConsoleKit"
+#define CK_MANAGER_DBUS_PATH   CK_DBUS_PATH "/Manager"
+#define DBUS_SESSION_INTERFACE DBUS_NAME ".Session"
+#define DBUS_MANAGER_INTERFACE DBUS_NAME ".Manager"
+
 G_BEGIN_DECLS
 
 #define CK_TYPE_MANAGER         (ck_manager_get_type ())

--- a/src/ck-seat.c
+++ b/src/ck-seat.c
@@ -36,6 +36,7 @@
 
 #include "ck-seat.h"
 #include "ck-marshal.h"
+#include "ck-manager.h"
 #include "ck-session.h"
 #include "ck-vt-monitor.h"
 #include "ck-run-programs.h"
@@ -49,6 +50,7 @@
 struct CkSeatPrivate
 {
         char            *id;
+        char            *path;
         CkSeatKind       kind;
         GHashTable      *sessions;
         GPtrArray       *devices;
@@ -776,7 +778,7 @@ ck_seat_add_session (CkSeat         *seat,
 
         g_hash_table_insert (seat->priv->sessions, g_strdup (ssid), g_object_ref (session));
 
-        ck_session_set_seat_id (session, seat->priv->id, NULL);
+        ck_session_set_seat_id (session, seat->priv->id, seat->priv->path, NULL);
 
         g_signal_connect_object (session, "activate", G_CALLBACK (session_activate), seat, G_CONNECT_AFTER);
         /* FIXME: attach to property notify signals? */
@@ -915,6 +917,11 @@ ck_seat_get_id (CkSeat         *seat,
         return TRUE;
 }
 
+const char *ck_seat_get_path (CkSeat *seat)
+{
+        return seat->priv->path;
+}
+
 static gboolean
 dbus_get_id (ConsoleKitSeat        *ckseat,
              GDBusMethodInvocation *context)
@@ -925,7 +932,7 @@ dbus_get_id (ConsoleKitSeat        *ckseat,
 
         g_return_val_if_fail (CK_IS_SEAT (seat), FALSE);
 
-        console_kit_seat_complete_get_id (ckseat, context, seat->priv->id);
+        console_kit_seat_complete_get_id (ckseat, context, seat->priv->path);
         return TRUE;
 }
 
@@ -975,11 +982,11 @@ ck_seat_register (CkSeat *seat)
                 return FALSE;
         }
 
-        g_debug ("exporting path %s", seat->priv->id);
+        g_debug ("exporting path %s", seat->priv->path);
 
         if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (ckseat),
                                                seat->priv->connection,
-                                               seat->priv->id,
+                                               seat->priv->path,
                                                &error)) {
                 if (error != NULL) {
                         g_critical ("error exporting interface: %s", error->message);
@@ -1127,9 +1134,7 @@ _ck_seat_set_kind (CkSeat    *seat,
         } else {
                 /* FIXME: At some point we should properly map this to the
                  * udev/devattr seat name when we do multi-seat */
-                gchar *sid = g_path_get_basename(seat->priv->id);
-                console_kit_seat_set_name (CONSOLE_KIT_SEAT (seat), sid);
-                g_free(sid);
+                console_kit_seat_set_name (CONSOLE_KIT_SEAT (seat), seat->priv->id);
         }
 }
 
@@ -1202,6 +1207,8 @@ ck_seat_constructor (GType                  type,
                 seat->priv->vt_monitor = ck_vt_monitor_new ();
                 g_signal_connect (seat->priv->vt_monitor, "active-changed", G_CALLBACK (active_vt_changed), seat);
         }
+
+        seat->priv->path = g_strdup_printf ("%s/%s", CK_DBUS_PATH, seat->priv->id);
 
         return G_OBJECT (seat);
 }
@@ -1306,6 +1313,7 @@ ck_seat_finalize (GObject *object)
         g_ptr_array_free (seat->priv->devices, TRUE);
         g_hash_table_destroy (seat->priv->sessions);
         g_free (seat->priv->id);
+        g_free (seat->priv->path);
 
         G_OBJECT_CLASS (ck_seat_parent_class)->finalize (object);
 }

--- a/src/ck-seat.h
+++ b/src/ck-seat.h
@@ -111,6 +111,7 @@ gboolean            ck_seat_remove_device       (CkSeat                *seat,
 gboolean            ck_seat_get_id                (CkSeat                *seat,
                                                    char                 **sid,
                                                    GError               **error);
+const char        * ck_seat_get_path              (CkSeat                *seat);
 gboolean            ck_seat_get_sessions          (CkSeat                *seat,
                                                    GPtrArray            **sessions,
                                                    GError               **error);

--- a/src/ck-session.h
+++ b/src/ck-session.h
@@ -142,6 +142,7 @@ gboolean            ck_session_set_cookie             (CkSession             *se
                                                        GError               **error);
 gboolean            ck_session_set_seat_id            (CkSession             *session,
                                                        const char            *sid,
+                                                       const char            *path,
                                                        GError               **error);
 gboolean            ck_session_set_login_session_id   (CkSession             *session,
                                                        const char            *login_session_id,

--- a/src/ck-session.h
+++ b/src/ck-session.h
@@ -112,6 +112,7 @@ void                ck_session_set_session_controller (CkSession             *se
 gboolean            ck_session_get_id                 (CkSession             *session,
                                                        char                 **ssid,
                                                        GError               **error);
+const char        * ck_session_get_path               (CkSession             *session);
 gboolean            ck_session_get_seat_id            (CkSession             *session,
                                                        char                 **sid,
                                                        GError               **error);


### PR DESCRIPTION
It it took quite a bit of work but now ConsoleKit does not confuse IDs and paths.

This unfortunately may break consumers. At least Polkit is affected as it also treats IDs as paths. It can be easily patched to handle both cases, though.

Based on #142 