### PR TITLE
Fix crash at the end of Session.Activate call.

### DIFF
--- a/src/ck-seat.c
+++ b/src/ck-seat.c
@@ -699,7 +699,7 @@ session_activate (CkSession             *session,
 {
         TRACE ();
 
-        return ck_seat_activate_session (seat, session, context);
+        return ck_seat_activate_session (seat, session, NULL);
 
 }
 


### PR DESCRIPTION
This call doesn't have a return value, however ck_seat_activate_session() attaches the call context (GDBusMethodInvocation*) to a signal handler. The handler gets called after the initial DBus call finishes which leads to use of already-freed context in activated_cb().