### PR TITLE
Add -s/--service argument to ck-launch-session.

### DIFF
--- a/data/ConsoleKit.conf
+++ b/data/ConsoleKit.conf
@@ -77,6 +77,9 @@
            send_member="OpenSession"/>
     <allow send_destination="org.freedesktop.ConsoleKit"
            send_interface="org.freedesktop.ConsoleKit.Manager"
+           send_member="OpenSessionWithParameters"/>
+    <allow send_destination="org.freedesktop.ConsoleKit"
+           send_interface="org.freedesktop.ConsoleKit.Manager"
            send_member="CloseSession"/>
     <allow send_destination="org.freedesktop.ConsoleKit"
            send_interface="org.freedesktop.ConsoleKit.Manager"

--- a/libck-connector/ck-connector.c
+++ b/libck-connector/ck-connector.c
@@ -80,6 +80,7 @@ static struct {
         { "x11-display",        DBUS_TYPE_STRING },
         { "remote-host-name",   DBUS_TYPE_STRING },
         { "session-type",       DBUS_TYPE_STRING },
+        { "session-service",    DBUS_TYPE_STRING },
         { "is-local",           DBUS_TYPE_BOOLEAN },
         { "unix-user",          DBUS_TYPE_INT32 },
 };
@@ -719,10 +720,6 @@ ck_connector_get_runtime_dir (CkConnector *connector,
         reply = NULL;
         message = NULL;
         runtime_dir = NULL;
-
-        if (!connector->session_created || connector->cookie == NULL) {
-                return NULL;
-        }
 
         dbus_error_init (&local_error);
         message = dbus_message_new_method_call ("org.freedesktop.ConsoleKit",


### PR DESCRIPTION
Currently there is no way to have `Session.GetSessionService()` return a value different from "unspecified". This change allows the caller of `ck-launch-session` to specify the PAM service that was used to start the session.

I'm not sure what security implications may arise from allowing calls to OpenSessionWithParameters. I skimmed through the code and it feels safe.