### PR TITLE
FreeBSD: support S0ix/s2idle suspend

### DIFF
--- a/src/ck-sysdeps-freebsd.c
+++ b/src/ck-sysdeps-freebsd.c
@@ -512,7 +512,11 @@ freebsd_supports_sleep_state (const gchar *state)
         gboolean ret = FALSE;
         gchar *sleep_states;
 
+#if __FreeBSD_version < 1600018
         sleep_states = get_string_sysctl (NULL, "hw.acpi.supported_sleep_state");
+#else
+        sleep_states = get_string_sysctl (NULL, "kern.power.supported_stype");
+#endif
         if (sleep_states != NULL) {
                 if (strstr (sleep_states, state) != NULL)
                         ret = TRUE;
@@ -526,13 +530,21 @@ freebsd_supports_sleep_state (const gchar *state)
 gboolean
 ck_system_can_suspend (void)
 {
+#if __FreeBSD_version < 1600018
         return freebsd_supports_sleep_state ("S3");
+#else
+        return freebsd_supports_sleep_state ("suspend_to_idle");
+#endif
 }
 
 gboolean
 ck_system_can_hibernate (void)
 {
+#if __FreeBSD_version < 1600018
         return freebsd_supports_sleep_state ("S4");
+#else
+        return freebsd_supports_sleep_state ("fw_hibernate");
+#endif
 }
 
 gboolean

--- a/tools/freebsd/ck-system-suspend
+++ b/tools/freebsd/ck-system-suspend
@@ -1,11 +1,7 @@
 #!/bin/sh
 
-#Try for common tools
-if [ -x "/sbin/acpiconf" ] ; then
-	/sbin/acpiconf -s 3
-	exit $?
-elif [ -x "/usr/sbin/acpiconf" ] ; then
-	/usr/sbin/acpiconf -s 3
+if [ -x "/usr/sbin/zzz" ] ; then
+	/usr/sbin/zzz
 	exit $?
 else
 	exit 1


### PR DESCRIPTION
On FreeBSD-CURRENT, there is a new sysctl to query for power state support, which supplants the existing ACPI-named one. The new sysctl is part of the greater project in FreeBSD to support the new power states/paradigms.

Also use `/usr/sbin/zzz` consistently since it automagically invokes the correct suspend method. Hibernate still uses `acpiconf` for now but there is work planned to replace this usage too.